### PR TITLE
New configurations for Privacy Pass to aid integrations

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,7 +28,12 @@
         "BuildRedeemHeader": true,
         "verifyProof": true,
         "ProdCommitmentConfig": true,
-        "createShake256": true
+        "PPConfigs": true,
+        "CHL_BYPASS_SUPPORT": true,
+        "CHL_BYPASS_RESPONSE": true,
+        "ACTIVE_CONFIG": true,
+        "createShake256": true,
+        "setActiveCommitments": true
     },
     "rules": {
         "no-trailing-spaces": "error",

--- a/README.md
+++ b/README.md
@@ -17,12 +17,14 @@ The extension is compatible with [Chrome](https://chrome.google.com/webstore/det
      * [Firefox](#firefox)
      * [Chrome](#chrome)
   * [Plugin overview](#plugin-overview)
+	 * [Configuration](#configuration)
      * [Workflow](#workflow)
      * [Message formatting](#message-formatting)
         * [Issuance request](#issuance-request)
         * [Issue response](#issue-response)
         * [Redemption request (privacy pass)](#redemption-request-privacy-pass)
         * [Redemption response](#redemption-response)
+  * [Integrating with Privacy Pass](integrating-with-privacy-pass)
   * [Team](#team)
   * [Design](#design)
   * [Cryptography](#cryptography)
@@ -57,7 +59,7 @@ Same as above, except the extension should be loaded at `chrome://extensions` in
 
 - background.js: Processes the necessary interactions with web-pages directly. Sends messages and processes edge replies
 
-- config.js: Config file containing commitments to edge private key for checking DLEQ proofs
+- config.js: Config file that decides the workflow for Privacy Pass
 
 - content.js: (currently unused) Content script for reading page html
 
@@ -70,6 +72,10 @@ Same as above, except the extension should be loaded at `chrome://extensions` in
 - In the following we may use 'pass' or 'token' interchangeably. In short, a token refers to the random nonce that is blind signed by the edge. 
 
 - A pass refers to the object that the extension sends to the edge in order to bypass an internet challenge. We will safely assume throughout that challenges manifest themselves as CAPTCHAs
+
+### Configuration
+
+The configuration of Privacy Pass is now determined by the values set in config.js. We have currently have an example configuration along with one that is used for bypassing Cloudflare CAPTCHAs. Integrating with Privacy Pass essentially amounts to writing a new configuration. We provide documentation of each of the config options in [CONFIG.md](https://github.com/privacypass/challenge-bypass-extension/blob/master/CONFIG.md).
 
 ### Workflow
 
@@ -193,6 +199,10 @@ Server response header used if errors occur when verifying the privacy pass.
 - Header: 
 
 	`"CF-Chl-Bypass-Resp":"<error-resp>"`
+
+## Integrating with Privacy Pass
+
+Privacy Pass is completely open-source, integrations can be handled by writing a new config to be placed in config.js. See [Configuration](#configuration) for more details.
 
 ## Team
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1,0 +1,127 @@
+# Privacy Pass configuration
+
+Privacy Pass interprets uses cryptographic tokens to bypass internet challenges from certain providers. In this doc, we discuss the configuration file that Privacy Pass uses for interpreting when tokens should be sent for signing/redemption.
+
+## config.js
+
+Holds the various configurations as JavaScript JSON structs for the providers that Privacy Pass interacts with. Currently, only the Cloudflare config is active. There is an example conifg, there is also an in progress config for the CAPTCHA provider FunCAPTCHA. In the following we will highlight how each config field is used.
+
+### config["id"]
+
+A unique identifier highlighting which config is used. Currently cfConfig.id = 1, all other configs should be added with unique "id" values.
+
+### config["sign"]
+
+A bool dictating whether Privacy Pass should send tokens for signing. 
+
+### config["redeem"]
+
+A bool dictating whether Privacy Pass should send tokens for redemption.
+
+### config["sign-reload"]
+
+A bool dictating whether the page should be reloaded after tokens are successfully signed
+
+### config["sign-resp-format"]
+
+Format of the response (as a string) to a signing request. Currently, support "string" or "json". When "string" is used, expect the signed tokens to be included (base-64 encoded) in the HTTP response body in the form `signatures= || <signed-tokens> || <Batch-DLEQ-Resp>`. When "json" is used, expect the signed tokens to be included (base-64 encoded) as a JSON struct with key: "signatures" and value `<signed-tokens> || <Batch-DLEQ-Resp>`.
+
+### config["storage-key-tokens"]
+
+The string key under which the tokens for the active config are stored in local storage. This should be unique for each config to prevent tokens being spent for inconsistent providers.
+
+### config["storage-key-count"]
+
+The string key corresponding to the number of tokens currently held in local storage (under config["storage-key-tokens"]). This should also be unique per config.
+
+### config["max-spends"]
+
+The integer number of tokens that should be redeemed per host in each interaction. This prevents Privacy Pass from repeatedly spending tokens for the same host (if some unknown issues occur, for example).
+
+### config["max-tokens"]
+
+The integer number of tokens that should be held by Privacy Pass at any one time.
+
+### config["tokens-per-request"]
+
+The integer number of tokens that should be sent with each signing request. For Cloudflare, there is also a server-side upper bound of 100 tokens for each signing request. We recommend that this is enforced to prevent unlimited numbers of tokens being signed.
+
+### config["var-reset"]
+
+A bool dictating whether the set of variables holding previous redemption information should be reset (see resetVars() in background.js). We recommend this is set to true, since these variables prevent tokens from being spent in the future.
+
+### config["var-reset-ms"]
+
+The time intervals (ms) by which the variables from above are reset.
+
+### config["commitments"]
+
+Hex-encoded elliptic curve commitment values for verifying DLEQ proofs. These essentially amount to public keys issued by the provider. The values of "G" and "H" held in config["commitments"]["dev"] should be used for development purposes. Those held in config["commitments"]["prod"] should be used in the production environment.
+
+### config["spending-restrictions"]
+
+A JSON struct of restrictions for redeeming tokens
+
+#### config["spending-restrictions"]["status-code"]
+
+An integer corresponding to the status code returned by the server. This HTTP status code is checked before a redemption is initiated, for Cloudflare this value is set to 403. That is, token redemptions can only occur after a HTTP response with status code 403 is received.
+
+#### config["spending-restrictions"]["iframe"]
+
+A bool indicating that redemptions can only occur after a HTTP response received from an iframe. This is not used by the CF config but is intended for future integrations.
+
+#### config["spending-restrictions"]["max-redirects"]
+
+An integer dictating the number of times that tokens should be spent after requests have been redirected. That is, consider a HTTP response that Privacy Pass deems suitable to initiate a redemption. This number indicates how may redemption HTTP requests will be tolerated where the response from the server results in HTTP redirection.
+
+#### config["spending-restrictions"]["new-tabs"]
+
+An array of strings indicating that the tab that is open corresponds to a new tab (and thus token redemption should not occur).
+
+#### config["spending-restrictions"]["bad-navigation"]
+
+An array of strings corresponding to chrome.webNavigation methods that indicate navigation types where tokens should not be redeemed. In the case of Cloudflare, this is limited to `auto_subframe` navigations that are not used for Cloudflare CAPTCHAs.
+
+#### config["spending-restrictions"]["bad-transition"]
+
+Similar to above, except for transition types. For Cloudflare, we rule out redemption requests when `server_redirect` is the transition type.
+
+#### config["spending-restrictions"]["valid-redirects"]
+
+An array of strings indicating the URL redirections that are tolerated when tokens are being redeemed. For example, redemptions that upgrade HTTP connections to HTTPS connections.
+
+#### config["spending-restrictions"]["valid-transitions"]
+
+An array of strings indicating the transition types that are definitely valid, when considering whether redemption requests should be sanctioned.
+
+#### config["spending-action"]["urls"]
+
+URLs that activate WebRequest listeners, "`<all_urls>`" corresponds to matching all possible URLs.
+
+#### config["spending-action"]["redeem-method"]
+
+A string that determines the method that token redemptions are handled. Currently the only methods that is supported is `"reload"`. This means that tokens are redeemed by reloading the page and appending tokens to the subsequent HTTP request.
+
+#### config["spending-action"]["header-name"]
+
+The name of the header that contains a token for redemption.
+
+#### config["cookies"]["check-cookies"]
+
+A boolean value that determines cookies should be checked before tokens are sent for redemption. That is, a token is not redeemed if the browser has a clearance cookie for the URL that redemption occurring for.
+
+#### config["cookies"]["clearance-cookie"]
+
+A string that specifies the specific name of the type of clearance cookie used by the provider. In the case of Cloudflare, this is `"cf_clearance"`.
+
+#### config["captcha-domain"]
+
+A string specifying a domain where users can obtain signed tokens by solving a challenge/CAPTCHA. This is helpful to allow users to build up initial stockpiles of tokens before they browse.
+
+#### config["error-codes"]["verify-error"]
+
+String error code that the server returns if token redemption fails due to a signature verification error.
+
+#### config["error-codes"]["connection-error"]
+
+String error code that the server returns if an internal connection error occurs server-side.

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1,6 +1,6 @@
 # Privacy Pass configuration
 
-Privacy Pass interprets uses cryptographic tokens to bypass internet challenges from certain providers. In this doc, we discuss the configuration file that Privacy Pass uses for interpreting when tokens should be sent for signing/redemption.
+Privacy Pass uses cryptographic tokens to bypass internet challenges from certain providers. In this doc, we discuss the configuration file that Privacy Pass uses for interpreting when tokens should be sent for signing/redemption. See config.js for an example configuration (exampleConfig) describing the correct format of the JSON struct.
 
 ## config.js
 

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -161,14 +161,8 @@ function processHeaders(details) {
         if (isBypassHeader(header) && SPEND_STATUS_CODE.indexOf(details.statusCode) > -1) {
             let iframe = (details.frameId > 0);
             // check if the token should only be spent on an iframe
-            if (SPEND_IFRAME) {
-                if (!iframe) {
-                    activated = false;
-                } else {
-                    activated = true;
-                }
-            } else {
-                activated = true;
+            if ((SPEND_IFRAME && iframe) || !SPEND_IFRAME) {
+                activated = true
             }
         }
     }
@@ -177,7 +171,7 @@ function processHeaders(details) {
     if (activated && !spentUrl[url.href]) {
         let redeemOccurred = false;
         if (DO_REDEEM) {
-            if (countStoredTokens() > 0 && activated) {
+            if (countStoredTokens() > 0) {
                 redeemOccurred = attemptRedeem(url, details.tabId);
             } else if (countStoredTokens() == 0) {
                 // Update icon to show user that token may be spent here

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -224,7 +224,7 @@ function attemptRedeem(url, respTabId) {
     } else {
         // If cookies aren't checked then we always attempt to redeem.
         fireRedeem(url, respTabId);
-        return true;
+        fired = true;
     }
     return fired;
 }
@@ -241,7 +241,7 @@ function fireRedeem(url, respTabId) {
             futureReload[respTabId] = url.href;
         }
     } else {
-        throw new Error("[privacy-pass]: Incompatible redeem method selected.");
+        throw new Error("[privacy-pass]: Incompatible redeem method selected. Only 'reload' is supported currently.");
     }
 }
 
@@ -330,7 +330,7 @@ function beforeRequest(details) {
     xhrSignRequest(xhrInfo, details.url, details.tabId);
 
     // Cancel the original request
-    return {cancel: true};
+    return {redirectUrl: "javascript:void(0)"};
 }
 
 // Sending tokens to be signed for Cloudflare

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -5,13 +5,113 @@
  */
 /* exported DevCommitmentConfig */
 /* exported ProdCommitmentConfig */
+/* exported CHL_BYPASS_SUPPORT */
+/* exported CHL_BYPASS_RESPONSE */
+/* exported PPConfigs */
 
-const DevCommitmentConfig = {
-    "G":"BIpWWWWFtDRODAHEzZlvjKyDwQAdh72mYKMAsGrtwsG7XmMxsy89gfiOFbX3RZ9Ik6jEYWyJB0TmnWNVeeZBt5Y=",
-    "H":"BKjGppSCZCsL08YlF4MJcml6YkCglMvr56WlUOFjn9hOKXNa0iB9t8OHXW7lARIfYO0CZE/t1SlPA1mXdi/Rcjo="
+const CHL_BYPASS_SUPPORT  = "cf-chl-bypass"; // header from server to indicate that
+const CHL_BYPASS_RESPONSE = "cf-chl-bypass-resp"; // response header from server, e.g. with erorr code
+
+const exampleConfig = {
+	"id": 0,
+	"sign": true, // sets whether tokens should be sent for signing
+	"redeem": true, // sets whether tokens should be sent for redemption
+	"sign-reload": true, // whether pages should be reloaded after signing tokens (e.g. to immediately redeem a token)
+	"sign-resp-format": "string", // formatting of response to sign request (string or json)
+	"storage-key-tokens": "eg-bypass-tokens", // key for local storage for accessing stored tokens
+	"storage-key-count": "eg-token-count", // key for local storage token count
+	"max-spends": 3, // for each host header, sets the max number of tokens that will be spent
+	"max-tokens": 10, // max number of tokens held by the extension
+	"tokens-per-request": 5, // number of tokens sent for each signing request (e.g. 30 for CF)
+	"var-reset": true, // whether variables should be reset after time limit expires
+	"var-reset-ms": 100, // variable reset time limit
+	"commitments": {
+		"dev": {
+			"G": "",
+			"H": "",
+		},
+		"prod": {
+			"G": "", // public generator of P256
+			"H": "", // public generator raised by power of secret key in GF(p)
+		}
+	}, // public key commitments for verifying DLEQ proofs (dev/prod) in curve P256
+	"spending-restrictions": {
+		"status-code": [200], // array of status codes that should trigger token redemption (e.g. 403 for CF)
+		"iframe": false, // set true if redemption should only occur in iframe
+		"max-redirects": "3", // when page redirects occur, sets the max number of redirects that tokens will be spent on
+		"new-tabs": ["about:privatebrowsing", "chrome://", "about:blank"], // urls that should not trigger page reloads/redemptions (these should probably be standard)
+		"bad-navigation": ["auto_subframe"], // navigation types that should not trigger page reloads/redemptions (see: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/webNavigation/TransitionType)
+		"bad-transition": ["server_redirect"], // transition types that should not trigger page reloads/redemptions (see: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/webNavigation/TransitionType)
+		"valid-redirects": ["https://","https://www.","http://www."], // valid redirects that should trigger token redemptions
+		"valid-transitions": ["link", "typed", "auto_bookmark", "reload"], // transition types that fine for triggering redemptions (see: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/webNavigation/TransitionType)
+	}, // These spending restrictions are examples that apply in the CF case
+	"spend-action": {
+		"urls": "<all_urls>", // urls that listeners act on
+		"redeem-method": "", // what method to use to perform redemption, currently we support "reload" for CF.
+		"header-name": "challenge-bypass-token", // name of header for sending redemption token
+	},
+	"cookies": {
+		"check-cookies": true, // whether cookies should be checked before spending
+		"clearance-cookie": "", // name of clearance cookies for checking (cookies that are optionally acquired after redemption occurs)
+	},
+	"captcha-domain": "", // optional domain for acquiring tokens
+	"error-codes": {
+		"verify-error": "5", // error code sent by server for verification error
+		"connection-error": "6", // error code sent by server for connection error
+	} // generic error codes (can add more)
 }
 
-const ProdCommitmentConfig = {
-    "G":"BOidEuO9HSJsMZYE/Pfc5D+0ELn0bqhjEef2O0u+KAw3fPMHHXtVlEBvYjE5I/ONf9SyTFSkH3mLNHkS06Du6hQ=",
-    "H":"BHOPNAWXRi4r/NEptOiLOp8MSwcX0vHrVDRXv16Jnowc1eXXo5xFFKIOI6mUp8k9/eca5VY07dBhAe8QfR/FSRY="
-}
+// The configuration used by Cloudflare
+const cfConfig = {
+	"id": 1,
+	"sign": true,
+	"redeem": true,
+	"sign-reload": true,
+	"sign-resp-format": "string",
+	"storage-key-tokens": "cf-bypass-tokens",
+	"storage-key-count": "cf-token-count",
+	"max-redirects": 3,
+	"max-spends": 3,
+	"max-tokens": 300,
+	"tokens-per-request": 30,
+	"var-reset": true,
+	"var-reset-ms": 2000,
+	"commitments": {
+		"dev": {
+			"G": "BIpWWWWFtDRODAHEzZlvjKyDwQAdh72mYKMAsGrtwsG7XmMxsy89gfiOFbX3RZ9Ik6jEYWyJB0TmnWNVeeZBt5Y=",
+			"H": "BKjGppSCZCsL08YlF4MJcml6YkCglMvr56WlUOFjn9hOKXNa0iB9t8OHXW7lARIfYO0CZE/t1SlPA1mXdi/Rcjo=",
+		},
+		"prod": {
+			"G": "BOidEuO9HSJsMZYE/Pfc5D+0ELn0bqhjEef2O0u+KAw3fPMHHXtVlEBvYjE5I/ONf9SyTFSkH3mLNHkS06Du6hQ=",
+			"H": "BHOPNAWXRi4r/NEptOiLOp8MSwcX0vHrVDRXv16Jnowc1eXXo5xFFKIOI6mUp8k9/eca5VY07dBhAe8QfR/FSRY=",
+		}
+	},
+	"spending-restrictions": {
+		"status-code": [403],
+		"iframe": false,
+		"max-redirects": "3",
+		"new-tabs": ["about:privatebrowsing", "chrome://", "about:blank"],
+		"bad-navigation": ["auto_subframe"],
+		"bad-transition": ["server_redirect"],
+		"valid-redirects": ["https://","https://www.","http://www."],
+		"valid-transitions": ["link", "typed", "auto_bookmark", "reload"],
+	},
+	"spend-action": {
+		"urls": "<all_urls>",
+		"redeem-method": "reload",
+		"header-name": "challenge-bypass-token",
+	},
+	"cookies": {
+		"check-cookies": true,
+		"clearance-cookie": "cf_clearance"
+	},
+	"captcha-domain": "captcha.website",
+	"error-codes": {
+		"verify-error": "5",
+		"connection-error": "6",
+	}
+};
+
+// Ordering of configs should correspond to value of cf-chl-bypass header
+// i.e. the first config should have "id": 1, the second "id":2, etc.
+const PPConfigs = [exampleConfig,cfConfig];

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -9,7 +9,7 @@
 /* exported CHL_BYPASS_RESPONSE */
 /* exported PPConfigs */
 
-const CHL_BYPASS_SUPPORT  = "cf-chl-bypass"; // header from server to indicate that
+const CHL_BYPASS_SUPPORT  = "cf-chl-bypass"; // header from server to indicate that Privacy Pass is supported
 const CHL_BYPASS_RESPONSE = "cf-chl-bypass-resp"; // response header from server, e.g. with erorr code
 
 const exampleConfig = {

--- a/scripts/crypto.js
+++ b/scripts/crypto.js
@@ -2,6 +2,7 @@
  * This implements a 2HashDH-based token scheme using the SJCL ecc package.
  *
  * @author: George Tankersley
+ * @author: Alex Davidson
  */
 
 /*global sjcl*/
@@ -15,6 +16,7 @@
 /* exported signPoint */
 /* exported unblindPoint */
 /* exported verifyProof */
+/* exported setActiveCommitments */
 "use strict";
 
 var p256 = sjcl.ecc.curves.c256;
@@ -25,8 +27,9 @@ const MASK = ["0xff", "0x1", "0x3", "0x7", "0xf", "0x1f", "0x3f", "0x7f"];
 const DIGEST_INEQUALITY_ERR = "[privacy-pass]: Recomputed digest does not equal received digest";
 const PARSE_ERR = "[privacy-pass]: Error parsing proof";
 
-let activeG = ProdCommitmentConfig.G;
-let activeH = ProdCommitmentConfig.H;
+let ACTIVE_CONFIG = PPConfigs[0];
+let activeG = ACTIVE_CONFIG["commitments"]["prod"]["G"];
+let activeH = ACTIVE_CONFIG["commitments"]["prod"]["H"];
 
 // Performs the scalar multiplication k*P
 //
@@ -447,4 +450,9 @@ function encodePointForPRNG(point) {
     let hex = sjcl.codec.hex.fromBits(point.toBits());
     let newHex = UNCOMPRESSED_POINT_PREFIX + hex;
     return sjcl.codec.hex.toBits(newHex);
+}
+
+function setActiveCommitments() {
+    activeG = ACTIVE_CONFIG["commitments"]["prod"]["G"];
+    activeH = ACTIVE_CONFIG["commitments"]["prod"]["H"];
 }


### PR DESCRIPTION
* Workflow is now determine by config files. Eventually we hope to have configs for each different provider.
* Update signing to only send tokens when the cf-chl-bypass header is received.
* Also provide documentation to help consume the new config options and update the README.

This change is quite big because it involves refactoring a lot of the code so that we use the new variables in config.js. There is minimal new functionality beyond the new restriction on signing.