### PR TITLE
New configurations for Privacy Pass to aid integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,22 @@
 
 The Privacy Pass extension allows a user to bypass internet challenge pages on websites supporting Privacy Pass using a 'blind signature' protocol. This extension alleviates the burden of completing large numbers of internet challenges (such as CAPTCHAs) for honest users by allowing tokens to be gained for an initial solution. These tokens can be spent by the extension when future challenges are displayed to prevent human interaction. The 'blind' capability of the protocol that we use means that tokens that are issued by a server cannot be linked to tokens that are later redeemed. An example server implementation that is compatible with this extension is available [here](https://github.com/privacypass/challenge-bypass-server).
 
-The protocol we use is based on a realization of a 'Verifiable, Oblivious Pseudorandom Function' (VOPRF) first established by [Jarecki et al.](https://eprint.iacr.org/2014/650.pdf). For a technical description of the protocol see the [PROTOCOL.md](https://github.com/privacypass/challenge-bypass-extension/blob/master/docs/PROTOCOL.md). 
+The protocol we use is based on a realization of a 'Verifiable, Oblivious Pseudorandom Function' (VOPRF) first established by [Jarecki et al.](https://eprint.iacr.org/2014/650.pdf). For a technical description of the protocol see the [PROTOCOL.md](docs/PROTOCOL.md). 
 
 The protocol has received extensive review and testing, but this extension is a work in progress and we regard all components as beta releases. We welcome contributions from the wider community, and also feel free to notify us of any issues that occur. Pull requests and reviews of the extension detailed here are welcome and encouraged.
 
 Privacy Pass is currently supported by Cloudflare to allow users to redeem validly signed tokens instead of completing CAPTCHA solutions. Clients receive 30 signed tokens for each CAPTCHA that is initially solved.
 
 The extension is compatible with [Chrome](https://chrome.google.com/webstore/detail/privacy-pass/ajhmfdgkijocedmfjonnpjfojldioehi) and [Firefox](https://addons.mozilla.org/en-US/firefox/addon/privacy-pass/) (v48+).
+
+## Quickstart
+
+```
+git clone https://github.com/privacypass/challenge-bypass-extension.git && cd challenge-bypass-extension
+yarn install
+yarn build
+yarn test
+```
 
 ### Contents
 
@@ -17,12 +26,14 @@ The extension is compatible with [Chrome](https://chrome.google.com/webstore/det
      * [Firefox](#firefox)
      * [Chrome](#chrome)
   * [Plugin overview](#plugin-overview)
+	 * [Configuration](#configuration)
      * [Workflow](#workflow)
      * [Message formatting](#message-formatting)
         * [Issuance request](#issuance-request)
         * [Issue response](#issue-response)
         * [Redemption request (privacy pass)](#redemption-request-privacy-pass)
         * [Redemption response](#redemption-response)
+  * [Integrating with Privacy Pass](integrating-with-privacy-pass)
   * [Team](#team)
   * [Design](#design)
   * [Cryptography](#cryptography)
@@ -37,11 +48,11 @@ Download the latest stable release of the extension:
 
 ## Development
 
-- `git clone git@github.com:privacypass/challenge-bypass-extension.git`
+- `git clone https://github.com/privacypass/challenge-bypass-extension.git`
 - To build a new version of the extension: `yarn build`.
 - To run integration tests: `yarn test`.
 - To prepare a new distribution: `yarn dist`.
-- For linting: `cd addon && eslint .`
+- For linting: `yarn lint`
 - To test in the browser see below.
 
 ### Firefox
@@ -71,7 +82,7 @@ The following script files are used for the workflow of Privacy Pass and are fou
 
 - browserUtils.js: General utility functions that are used by background.js. We separate them so that we separate the specific browser API calls from the actual workflow.
 
-- config.js: Config file containing commitments to edge private key for checking DLEQ proofs
+- config.js: Config file that decides the workflow for Privacy Pass
 
 - content.js: (currently unused) Content script for reading page html
 
@@ -86,6 +97,10 @@ The following script files are used for the workflow of Privacy Pass and are fou
 Files that are used for testing are found in `test/`. These test files use their own compiled test file in `compiled/test_compiled.js`.
 
 In the following we may use 'pass' or 'token' interchangeably. In short, a token refers to the random nonce that is blind signed by the edge. A pass refers to the object that the extension sends to the edge in order to bypass an internet challenge. We will safely assume throughout that challenges manifest themselves as CAPTCHAs
+
+### Configuration
+
+The configuration of Privacy Pass is now determined by the values set in config.js. We have provided an example configuration, along with one that is used for bypassing Cloudflare CAPTCHAs. Integrating with Privacy Pass essentially amounts to writing a new configuration. We provide documentation of each of the config options in [CONFIG.md](docs/CONFIG.md).
 
 ### Workflow
 
@@ -145,7 +160,7 @@ Marshaled array used for sending signed tokens back to the user. This message is
 
 - `<signed-tokens>` is an array of compressed elliptic curve point, as above, that have been 'signed' by the edge. In the VOPRF model the 'signed' point is essentially a commitment to the edge's private key
 
-- `<proof>` is a base64 encoded JSON struct containing the necessary information for carrying out a DLEQ proof verification. In particular it contains response values `R` and `C` for verifying that the key used in signing is the same as the key stored in the commitment files. See [PROTOCOL.md](https://github.com/privacypass/challenge-bypass-extension/blob/master/docs/PROTOCOL.md) for more details.
+- `<proof>` is a base64 encoded JSON struct containing the necessary information for carrying out a DLEQ proof verification. In particular it contains response values `R` and `C` for verifying that the key used in signing is the same as the key stored in the commitment files. See [PROTOCOL.md](docs/PROTOCOL.md) for more details.
 
 - `<batch-proof>` is a base64 encoded JSON struct of the form:<sup>2</sup>
 
@@ -209,6 +224,10 @@ Server response header used if errors occur when verifying the privacy pass.
 - Header: 
 
 	`"CF-Chl-Bypass-Resp":"<error-resp>"`
+
+## Integrating with Privacy Pass
+
+Privacy Pass is completely open-source, integrations can be handled by writing a new config to be placed in config.js. See [Configuration](#configuration) for more details.
 
 ## Team
 

--- a/addon/.eslintrc.json
+++ b/addon/.eslintrc.json
@@ -41,8 +41,6 @@
         "reloadTabForCookie": true,
         "CHL_CAPTCHA_DOMAIN": true,
         "CHL_CLEARANCE_COOKIE": true,
-        "STORAGE_KEY_TOKENS": true,
-        "STORAGE_KEY_COUNT": true,
         "spendId": true,
         "spentTab": true,
         "timeSinceLastResp": true,
@@ -57,7 +55,15 @@
         "clear": true,
         "get": true,
         "set": true,
-        "UpdateCallback": true
+        "UpdateCallback": true,
+        "setActiveCommitments": true,
+        "CHECK_COOKIES": true,
+        "LISTENER_URLS": true,
+        "REDEEM_METHOD": true,
+        "PPConfigs": true,
+        "CHL_BYPASS_SUPPORT": true,
+        "CHL_BYPASS_RESPONSE": true,
+        "ACTIVE_CONFIG": true
     },
     "rules": {
         "no-trailing-spaces": "error",

--- a/addon/scripts/config.js
+++ b/addon/scripts/config.js
@@ -5,13 +5,107 @@
  */
 /* exported DevCommitmentConfig */
 /* exported ProdCommitmentConfig */
+/* exported CHL_BYPASS_SUPPORT */
+/* exported CHL_BYPASS_RESPONSE */
+/* exported PPConfigs */
 
-const DevCommitmentConfig = {
-    "G":"BIpWWWWFtDRODAHEzZlvjKyDwQAdh72mYKMAsGrtwsG7XmMxsy89gfiOFbX3RZ9Ik6jEYWyJB0TmnWNVeeZBt5Y=",
-    "H":"BKjGppSCZCsL08YlF4MJcml6YkCglMvr56WlUOFjn9hOKXNa0iB9t8OHXW7lARIfYO0CZE/t1SlPA1mXdi/Rcjo="
+const CHL_BYPASS_SUPPORT  = "cf-chl-bypass"; // header from server to indicate that Privacy Pass is supported
+const CHL_BYPASS_RESPONSE = "cf-chl-bypass-resp"; // response header from server, e.g. with erorr code
+
+const exampleConfig = {
+	"id": 0,
+	"sign": true, // sets whether tokens should be sent for signing
+	"redeem": true, // sets whether tokens should be sent for redemption
+	"sign-reload": true, // whether pages should be reloaded after signing tokens (e.g. to immediately redeem a token)
+	"sign-resp-format": "string", // formatting of response to sign request (string or json)
+	"max-spends": 3, // for each host header, sets the max number of tokens that will be spent
+	"max-tokens": 10, // max number of tokens held by the extension
+	"tokens-per-request": 5, // number of tokens sent for each signing request (e.g. 30 for CF)
+	"var-reset": true, // whether variables should be reset after time limit expires
+	"var-reset-ms": 100, // variable reset time limit
+	"commitments": {
+		"dev": {
+			"G": "",
+			"H": "",
+		},
+		"prod": {
+			"G": "", // public generator of P256
+			"H": "", // public generator raised by power of secret key in GF(p)
+		}
+	}, // public key commitments for verifying DLEQ proofs (dev/prod) in curve P256
+	"spending-restrictions": {
+		"status-code": [200], // array of status codes that should trigger token redemption (e.g. 403 for CF)
+		"max-redirects": "3", // when page redirects occur, sets the max number of redirects that tokens will be spent on
+		"new-tabs": ["about:privatebrowsing", "chrome://", "about:blank"], // urls that should not trigger page reloads/redemptions (these should probably be standard)
+		"bad-navigation": ["auto_subframe"], // navigation types that should not trigger page reloads/redemptions (see: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/webNavigation/TransitionType)
+		"bad-transition": ["server_redirect"], // transition types that should not trigger page reloads/redemptions (see: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/webNavigation/TransitionType)
+		"valid-redirects": ["https://","https://www.","http://www."], // valid redirects that should trigger token redemptions
+		"valid-transitions": ["link", "typed", "auto_bookmark", "reload"], // transition types that fine for triggering redemptions (see: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/webNavigation/TransitionType)
+	}, // These spending restrictions are examples that apply in the CF case
+	"spend-action": {
+		"urls": "<all_urls>", // urls that listeners act on
+		"redeem-method": "", // what method to use to perform redemption, currently we support "reload" for CF.
+		"header-name": "challenge-bypass-token", // name of header for sending redemption token
+	},
+	"cookies": {
+		"check-cookies": true, // whether cookies should be checked before spending
+		"clearance-cookie": "", // name of clearance cookies for checking (cookies that are optionally acquired after redemption occurs)
+	},
+	"captcha-domain": "", // optional domain for acquiring tokens
+	"error-codes": {
+		"verify-error": "5", // error code sent by server for verification error
+		"connection-error": "6", // error code sent by server for connection error
+	} // generic error codes (can add more)
 }
 
-const ProdCommitmentConfig = {
-    "G":"BOidEuO9HSJsMZYE/Pfc5D+0ELn0bqhjEef2O0u+KAw3fPMHHXtVlEBvYjE5I/ONf9SyTFSkH3mLNHkS06Du6hQ=",
-    "H":"BHOPNAWXRi4r/NEptOiLOp8MSwcX0vHrVDRXv16Jnowc1eXXo5xFFKIOI6mUp8k9/eca5VY07dBhAe8QfR/FSRY="
-}
+// The configuration used by Cloudflare
+const cfConfig = {
+	"id": 1,
+	"sign": true,
+	"redeem": true,
+	"sign-reload": true,
+	"sign-resp-format": "string",
+	"max-redirects": 3,
+	"max-spends": 3,
+	"max-tokens": 300,
+	"tokens-per-request": 30,
+	"var-reset": true,
+	"var-reset-ms": 2000,
+	"commitments": {
+		"dev": {
+			"G": "BIpWWWWFtDRODAHEzZlvjKyDwQAdh72mYKMAsGrtwsG7XmMxsy89gfiOFbX3RZ9Ik6jEYWyJB0TmnWNVeeZBt5Y=",
+			"H": "BKjGppSCZCsL08YlF4MJcml6YkCglMvr56WlUOFjn9hOKXNa0iB9t8OHXW7lARIfYO0CZE/t1SlPA1mXdi/Rcjo=",
+		},
+		"prod": {
+			"G": "BOidEuO9HSJsMZYE/Pfc5D+0ELn0bqhjEef2O0u+KAw3fPMHHXtVlEBvYjE5I/ONf9SyTFSkH3mLNHkS06Du6hQ=",
+			"H": "BHOPNAWXRi4r/NEptOiLOp8MSwcX0vHrVDRXv16Jnowc1eXXo5xFFKIOI6mUp8k9/eca5VY07dBhAe8QfR/FSRY=",
+		}
+	},
+	"spending-restrictions": {
+		"status-code": [403],
+		"max-redirects": "3",
+		"new-tabs": ["about:privatebrowsing", "chrome://", "about:blank"],
+		"bad-navigation": ["auto_subframe"],
+		"bad-transition": ["server_redirect"],
+		"valid-redirects": ["https://","https://www.","http://www."],
+		"valid-transitions": ["link", "typed", "auto_bookmark", "reload"],
+	},
+	"spend-action": {
+		"urls": "<all_urls>",
+		"redeem-method": "reload",
+		"header-name": "challenge-bypass-token",
+	},
+	"cookies": {
+		"check-cookies": true,
+		"clearance-cookie": "cf_clearance"
+	},
+	"captcha-domain": "captcha.website",
+	"error-codes": {
+		"verify-error": "5",
+		"connection-error": "6",
+	}
+};
+
+// Ordering of configs should correspond to value of cf-chl-bypass header
+// i.e. the first config should have "id": 1, the second "id":2, etc.
+const PPConfigs = [exampleConfig,cfConfig];

--- a/addon/scripts/crypto.js
+++ b/addon/scripts/crypto.js
@@ -17,6 +17,7 @@
 /* exported unblindPoint */
 /* exported verifyProof */
 /* exported getBigNumFromBytes */
+/* exported setActiveCommitments */
 "use strict";
 
 var p256 = sjcl.ecc.curves.c256;
@@ -27,8 +28,9 @@ const MASK = ["0xff", "0x1", "0x3", "0x7", "0xf", "0x1f", "0x3f", "0x7f"];
 const DIGEST_INEQUALITY_ERR = "[privacy-pass]: Recomputed digest does not equal received digest";
 const PARSE_ERR = "[privacy-pass]: Error parsing proof";
 
-let activeG = ProdCommitmentConfig.G;
-let activeH = ProdCommitmentConfig.H;
+let ACTIVE_CONFIG = PPConfigs[0];
+let activeG = ACTIVE_CONFIG["commitments"]["prod"]["G"];
+let activeH = ACTIVE_CONFIG["commitments"]["prod"]["H"];
 
 // Performs the scalar multiplication k*P
 //
@@ -315,6 +317,9 @@ function verifyProof(proofObj, tokens, signatures) {
     }
     const chkM = tokens;
     const chkZ = signatures;
+    if (chkM.length !== chkZ.length) {
+        return false;
+    }
     const pointG = sec1DecodePoint(activeG);
     const pointH = sec1DecodePoint(activeH);
 
@@ -460,4 +465,9 @@ function encodePointForPRNG(point) {
     let hex = sjcl.codec.hex.fromBits(point.toBits());
     let newHex = UNCOMPRESSED_POINT_PREFIX + hex;
     return sjcl.codec.hex.toBits(newHex);
+}
+
+function setActiveCommitments() {
+    activeG = ACTIVE_CONFIG["commitments"]["prod"]["G"];
+    activeH = ACTIVE_CONFIG["commitments"]["prod"]["H"];
 }

--- a/addon/scripts/listeners.js
+++ b/addon/scripts/listeners.js
@@ -3,7 +3,10 @@
  *
  * @author: Alex Davidson
  */
+/* exported LISTENER_URLS */
 "use strict";
+
+let LISTENER_URLS = ACTIVE_CONFIG["spend-action"]["urls"];
 
 /* Event listeners manage control flow
     - web request listeners act to send signable/redemption tokens when needed
@@ -14,7 +17,7 @@
 
 chrome.webRequest.onCompleted.addListener(
     function(details) { handleCompletion(details); },
-    { urls: ["<all_urls>"] },
+    { urls: [LISTENER_URLS] },
 );
 
 chrome.webRequest.onBeforeRedirect.addListener(
@@ -23,7 +26,7 @@ chrome.webRequest.onBeforeRedirect.addListener(
         let newUrl = new URL(details.redirectUrl);
         processRedirect(details, oldUrl, newUrl);
     },
-    { urls: ["<all_urls>"] },
+    { urls: [LISTENER_URLS] },
 );
 
 // Watches headers for CF-Chl-Bypass and CF-Chl-Bypass-Resp headers.
@@ -32,7 +35,7 @@ chrome.webRequest.onHeadersReceived.addListener(
         let url = new URL(details.url);
         processHeaders(details, url);
     },                 // callback
-    { urls: ["<all_urls>"] },       // targeted pages
+    { urls: [LISTENER_URLS] },       // targeted pages
     ["responseHeaders", "blocking"] // desired traits
 );
 
@@ -42,7 +45,7 @@ chrome.webRequest.onBeforeSendHeaders.addListener(
         let url = new URL(details.url);
         return beforeSendHeaders(details, url);
     },        // callback
-    { urls: ["<all_urls>"] }, // targeted pages
+    { urls: [LISTENER_URLS] }, // targeted pages
     ["requestHeaders", "blocking"]
 );
 
@@ -56,7 +59,7 @@ chrome.webRequest.onBeforeRequest.addListener(
         }
         return {redirectUrl: "javascript:void(0)"};
     },            // callback
-    { urls: ["<all_urls>"] }, // targeted pages
+    { urls: [LISTENER_URLS] }, // targeted pages
     ["blocking"]              // desired traits
 );
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1,0 +1,115 @@
+# Privacy Pass configuration
+
+Privacy Pass uses cryptographic tokens to bypass internet challenges from certain providers. In this doc, we discuss the configuration file that Privacy Pass uses for interpreting when tokens should be sent for signing/redemption. See config.js for an example configuration (exampleConfig) describing the correct format of the JSON struct.
+
+## config.js
+
+Holds the various configurations as JavaScript JSON structs for the providers that Privacy Pass interacts with. Currently, only the Cloudflare config is active. There is an example config, there is also an in progress config for the CAPTCHA provider FunCAPTCHA. In the following we will highlight how each config field is used.
+
+### config["id"]
+
+A unique identifier highlighting which config is used. Currently cfConfig.id = 1, all other configs must be added with unique "id" values.
+
+### config["sign"]
+
+A bool dictating whether Privacy Pass should send tokens for signing. 
+
+### config["redeem"]
+
+A bool dictating whether Privacy Pass should send tokens for redemption.
+
+### config["sign-reload"]
+
+A bool dictating whether the page should be reloaded after tokens are successfully signed
+
+### config["sign-resp-format"]
+
+Format of the response (as a string) to a signing request. Currently, support "string" or "json". When "string" is used, expect the signed tokens to be included (base-64 encoded) in the HTTP response body in the form `signatures= || <signed-tokens> || <Batch-DLEQ-Resp>`. When "json" is used, expect the signed tokens to be included (base-64 encoded) as a JSON struct with key: "signatures" and value `<signed-tokens> || <Batch-DLEQ-Resp>`.
+
+### config["max-spends"]
+
+The integer number of tokens that should be redeemed per host in each interaction. This prevents Privacy Pass from repeatedly spending tokens for the same host (if some unknown issues occur, for example).
+
+### config["max-tokens"]
+
+The integer number of tokens that should be held by Privacy Pass at any one time.
+
+### config["tokens-per-request"]
+
+The integer number of tokens that should be sent with each signing request. For Cloudflare, there is also a server-side upper bound of 100 tokens for each signing request. We recommend that this is enforced to prevent unlimited numbers of tokens being signed.
+
+### config["var-reset"]
+
+A bool dictating whether the set of variables holding previous redemption information should be reset (see resetVars() in background.js). We recommend this is set to true, since these variables prevent tokens from being spent in the future.
+
+### config["var-reset-ms"]
+
+The time intervals (ms) by which the variables from above are reset.
+
+### config["commitments"]
+
+Hex-encoded elliptic curve commitment values for verifying DLEQ proofs. These essentially amount to public keys issued by the provider. The values of "G" and "H" held in config["commitments"]["dev"] should be used for development purposes. Those held in config["commitments"]["prod"] should be used in the production environment.
+
+### config["spending-restrictions"]
+
+A JSON struct of restrictions for redeeming tokens
+
+#### config["spending-restrictions"]["status-code"]
+
+An integer corresponding to the status code returned by the server. This HTTP status code is checked before a redemption is initiated, for Cloudflare this value is set to 403. That is, token redemptions can only occur after a HTTP response with status code 403 is received.
+
+#### config["spending-restrictions"]["max-redirects"]
+
+An integer dictating the number of times that tokens should be spent after requests have been redirected. That is, consider a HTTP response that Privacy Pass deems suitable to initiate a redemption. This number indicates how may redemption HTTP requests will be tolerated where the response from the server results in HTTP redirection.
+
+#### config["spending-restrictions"]["new-tabs"]
+
+An array of strings indicating that the tab that is open corresponds to a new tab (and thus token redemption should not occur).
+
+#### config["spending-restrictions"]["bad-navigation"]
+
+An array of strings corresponding to chrome.webNavigation methods that indicate navigation types where tokens should not be redeemed. In the case of Cloudflare, this is limited to `auto_subframe` navigations that are not used for Cloudflare CAPTCHAs.
+
+#### config["spending-restrictions"]["bad-transition"]
+
+Similar to above, except for transition types. For Cloudflare, we rule out redemption requests when `server_redirect` is the transition type.
+
+#### config["spending-restrictions"]["valid-redirects"]
+
+An array of strings indicating the URL redirections that are tolerated when tokens are being redeemed. For example, redemptions that upgrade HTTP connections to HTTPS connections.
+
+#### config["spending-restrictions"]["valid-transitions"]
+
+An array of strings indicating the transition types that are definitely valid, when considering whether redemption requests should be sanctioned.
+
+#### config["spending-action"]["urls"]
+
+URLs that activate WebRequest listeners, "`<all_urls>`" corresponds to matching all possible URLs.
+
+#### config["spending-action"]["redeem-method"]
+
+A string that determines the method that token redemptions are handled. Currently the only methods that is supported is `"reload"`. This means that tokens are redeemed by reloading the page and appending tokens to the subsequent HTTP request.
+
+#### config["spending-action"]["header-name"]
+
+The name of the header that contains a token for redemption.
+
+#### config["cookies"]["check-cookies"]
+
+A boolean value that determines cookies should be checked before tokens are sent for redemption. That is, a token is not redeemed if the browser has a clearance cookie for the URL that redemption occurring for.
+
+#### config["cookies"]["clearance-cookie"]
+
+A string that specifies the specific name of the type of clearance cookie used by the provider. In the case of Cloudflare, this is `"cf_clearance"`.
+
+#### config["captcha-domain"]
+
+A string specifying a domain where users can obtain signed tokens by solving a challenge/CAPTCHA. This is helpful to allow users to build up initial stockpiles of tokens before they browse.
+
+#### config["error-codes"]["verify-error"]
+
+String error code that the server returns if token redemption fails due to a signature verification error.
+
+#### config["error-codes"]["connection-error"]
+
+String error code that the server returns if an internal connection error occurs server-side.


### PR DESCRIPTION
Changes for #40.

* Switch workflow to using separate configs, e.g. for each provider.
* Update signing to only send tokens when the cf-chl-bypass header is received.
* New tests and changes to some existing ones.
* Provide documentation (docs/CONFIG.md) to help consume the new config options and update the README.

Succeeds the PR in #39.