### PR TITLE
Prevent null point errors

### DIFF
--- a/addon/.eslintrc.json
+++ b/addon/.eslintrc.json
@@ -20,7 +20,6 @@
         "decodeStorablePoint": true,
         "newRandomPoint": true,
         "sec1DecodePoint": true,
-        "signPoint": true,
         "unblindPoint": true,
         "getBigNumFromBytes": true,
         "CreateBlindToken": true,
@@ -76,7 +75,7 @@
         ],
         "no-console": [
             "error", {
-                "allow": ["error"]
+                "allow": ["error", "warn"]
             }
         ]
     }

--- a/addon/scripts/tokens.js
+++ b/addon/scripts/tokens.js
@@ -23,17 +23,27 @@
 //  r blinding factor, sjcl bignum
 function CreateBlindToken() {
     let t = newRandomPoint();
-    let bpt = blindPoint(t.point);
-    return { token: t.token, point: bpt.point, blind: bpt.blind };
+    let tok;
+    if (t) {
+        let bpt = blindPoint(t.point);
+        tok = { token: t.token, point: bpt.point, blind: bpt.blind };
+    }
+    return tok;
 }
 
 // returns: array of blind tokens
 function GenerateNewTokens(n) {
-    let i = 0;
-    let tokens = new Array(n);
-    for (i = 0; i < tokens.length; i++) {
-        tokens[i] = CreateBlindToken();
+    let tokens = [];
+    for (let i=0; i<n; i++) {
+        let tok = CreateBlindToken();
+        if (!tok) {
+            console.warn("[privacy-pass]: Tried to generate a random point on the curve, but failed.");
+            console.warn("[privacy-pass]: Will drop the null point.");
+        }
+        tokens[i] = tok;
     }
+    // remove array entries that are null
+    tokens = tokens.filter(function(ele) { return !!ele; });
     return tokens;
 }
 

--- a/test/tokens.test.js
+++ b/test/tokens.test.js
@@ -1,0 +1,51 @@
+/**
+* Integration tests for token generation functionality
+* 
+* @author: Alex Davidson
+*/
+import rewire from "rewire";
+var workflow = rewire("../addon/compiled/test_compiled.js");
+var URL = window.URL;
+
+/**
+* Functions
+*/
+const CreateBlindToken = workflow.__get__('CreateBlindToken');
+const GenerateNewTokens = workflow.__get__('GenerateNewTokens');
+let consoleMock;
+let CreateBlindTokenMock;
+beforeEach(() => {
+    consoleMock = {
+        warn: jest.fn()
+    }
+    workflow.__set__("console", consoleMock);
+    let count = 0;
+    CreateBlindTokenMock = function() {
+        let token;
+        if (count != 1) {
+            token = CreateBlindToken();
+        }
+        count++;
+        return token;
+    }
+});
+
+/**
+* Tests
+*/
+describe("check that null point errors are caught in token generation", () => {
+    test("check that token generation happens correctly", () => {
+        let tokens = GenerateNewTokens(3);
+        expect(tokens.length == 3).toBeTruthy();
+        let consoleNew = workflow.__get__("console");
+        expect(consoleNew.warn).not.toBeCalled();
+    });
+
+    test("check that null tokens are caught and ignored", () => {
+        workflow.__set__("CreateBlindToken", CreateBlindTokenMock);
+        let tokens = GenerateNewTokens(3);
+        expect(tokens.length == 2).toBeTruthy();
+        let consoleNew = workflow.__get__("console");
+        expect(consoleNew.warn).toBeCalled();
+    });
+});


### PR DESCRIPTION
Sometimes the random token generation would fail and curve points would be null. This would cause uncaught errors that would stop token generation.

Rewritten the token geenration logic so that null curve points are caught and ignored.

This addresses #50.

