### PR TITLE
Better data format for redemptions

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -197,6 +197,4 @@ full).
 #### config["send-h2c-params"]
 
 A boolean that determines whether the contents of config["h2c-params"] should
-actually be sent to the server. This currently defaults to off for cfConfig
-because the data format for issue requests is sub-optimal, and sending these
-parameters incurs a larger overhead than required.
+actually be sent to the server.

--- a/src/ext/config.js
+++ b/src/ext/config.js
@@ -99,7 +99,7 @@ const cfConfig = {
 		"hash": "sha256",
 		"method": "increment",
 	},
-	"send-h2c-params": false
+	"send-h2c-params": true
 };
 
 // Ordering of configs should correspond to value of cf-chl-bypass header

--- a/src/ext/redemption.js
+++ b/src/ext/redemption.js
@@ -20,8 +20,6 @@ function BuildRedeemHeader(token, host, path) {
     const sharedPoint = unblindPoint(token.blind, token.point);
     const derivedKey = deriveKey(sharedPoint, token.data);
 
-    // TODO: this could be more efficient, but it's easier to check correctness
-    // when everything is bytes
     const hostBits = sjcl.codec.utf8String.toBits(host);
     const hostBytes = sjcl.codec.bytes.fromBits(hostBits);
 

--- a/src/ext/redemption.js
+++ b/src/ext/redemption.js
@@ -20,24 +20,26 @@ function BuildRedeemHeader(token, host, path) {
     const sharedPoint = unblindPoint(token.blind, token.point);
     const derivedKey = deriveKey(sharedPoint, token.data);
 
-    // TODO: this could be more efficient, but it's easier to check correctness when everything is bytes
+    // TODO: this could be more efficient, but it's easier to check correctness
+    // when everything is bytes
     const hostBits = sjcl.codec.utf8String.toBits(host);
     const hostBytes = sjcl.codec.bytes.fromBits(hostBits);
 
     const pathBits = sjcl.codec.utf8String.toBits(path);
     const pathBytes = sjcl.codec.bytes.fromBits(pathBits);
 
-    const binding = createRequestBinding(derivedKey, [hostBytes, pathBytes]);
+    const b64Binding = createRequestBinding(derivedKey, [hostBytes, pathBytes]);
 
+    // Fortunately Go interprets base64-encoded strings as []bytes when
+    // unmarshaling JSON.
     let contents = [];
-    contents.push(token.data);
-    contents.push(binding);
-
+    contents.push(sjcl.codec.base64.fromBits(sjcl.codec.bytes.toBits(token.data)));
+    contents.push(b64Binding);
     if (SEND_H2C_PARAMS) {
         const h2cString = JSON.stringify(H2C_PARAMS);
         const h2cBits = sjcl.codec.utf8String.toBits(h2cString);
-        const h2cBytes = sjcl.codec.bytes.fromBits(h2cBits);
-        contents.push(h2cBytes);
+        const h2cB64 = sjcl.codec.base64.fromBits(h2cBits);
+        contents.push(h2cB64);
     }
 
     return btoa(JSON.stringify({ type: "Redeem", contents: contents}));
@@ -65,8 +67,7 @@ function createRequestBinding(key, data) {
         h.update(dataBits);
     }
 
-    const digestBytes = sjcl.codec.bytes.fromBits(h.digest());
-    return digestBytes;
+    return sjcl.codec.base64.fromBits(h.digest());
 }
 
 /**

--- a/test/beforeHeadersSend.test.js
+++ b/test/beforeHeadersSend.test.js
@@ -19,8 +19,8 @@ const EXAMPLE_HREF = "https://www.example.com";
 const CACHED_COMMITMENTS_STRING = "cached-commitments";
 const beforeSendHeaders = workflow.__get__('beforeSendHeaders');
 const setConfig = workflow.__get__('setConfig');
-const b64EncodedTokenNoH2CParams = "eyJ0eXBlIjoiUmVkZWVtIiwiY29udGVudHMiOltbMjQsNjIsNTYsMTAyLDc2LDEyNywyMDEsMTExLDE2MSwyMTgsMjQ5LDEwOSwzNCwxMjIsMTYwLDIxOSw5MywxODYsMjQ2LDEyLDE3OCwyNDksMjQxLDEwOCw2OSwxODEsNzcsMTQwLDE1OCwxMywyMTYsMTg0XSxbMjI3LDExLDk1LDIxNSwxNSwyMTUsMTM1LDI0LDEzNywxNzQsMjMzLDgsODYsMTQ4LDEzMCwxOTEsNDYsMTgzLDkyLDEwOCwxNjAsMjQ5LDE1OCwyMzEsMTU5LDIxOCwyNTQsODAsMTQ4LDQ0LDI5LDI1NF1dfQ==";
-const b64EncodedToken = "eyJ0eXBlIjoiUmVkZWVtIiwiY29udGVudHMiOltbMjQsNjIsNTYsMTAyLDc2LDEyNywyMDEsMTExLDE2MSwyMTgsMjQ5LDEwOSwzNCwxMjIsMTYwLDIxOSw5MywxODYsMjQ2LDEyLDE3OCwyNDksMjQxLDEwOCw2OSwxODEsNzcsMTQwLDE1OCwxMywyMTYsMTg0XSxbMjI3LDExLDk1LDIxNSwxNSwyMTUsMTM1LDI0LDEzNywxNzQsMjMzLDgsODYsMTQ4LDEzMCwxOTEsNDYsMTgzLDkyLDEwOCwxNjAsMjQ5LDE1OCwyMzEsMTU5LDIxOCwyNTQsODAsMTQ4LDQ0LDI5LDI1NF0sWzEyMywzNCw5OSwxMTcsMTE0LDExOCwxMDEsMzQsNTgsMzQsMTEyLDUwLDUzLDU0LDM0LDQ0LDM0LDEwNCw5NywxMTUsMTA0LDM0LDU4LDM0LDExNSwxMDQsOTcsNTAsNTMsNTQsMzQsNDQsMzQsMTA5LDEwMSwxMTYsMTA0LDExMSwxMDAsMzQsNTgsMzQsMTA1LDExMCw5OSwxMTQsMTAxLDEwOSwxMDEsMTEwLDExNiwzNCwxMjVdXX0=";
+const b64EncodedTokenNoH2CParams = "eyJ0eXBlIjoiUmVkZWVtIiwiY29udGVudHMiOlsiR0Q0NFpreC95VytoMnZsdElucWcyMTI2OWd5eStmRnNSYlZOako0TjJMZz0iLCI0d3RmMXcvWGh4aUpydWtJVnBTQ3Z5NjNYR3lnK1o3bm45citVSlFzSGY0PSJdfQ==";
+const b64EncodedToken = "eyJ0eXBlIjoiUmVkZWVtIiwiY29udGVudHMiOlsiR0Q0NFpreC95VytoMnZsdElucWcyMTI2OWd5eStmRnNSYlZOako0TjJMZz0iLCI0d3RmMXcvWGh4aUpydWtJVnBTQ3Z5NjNYR3lnK1o3bm45citVSlFzSGY0PSIsImV5SmpkWEoyWlNJNkluQXlOVFlpTENKb1lYTm9Jam9pYzJoaE1qVTJJaXdpYldWMGFHOWtJam9pYVc1amNtVnRaVzUwSW4wPSJdfQ==";
 let localStorage;
 let details;
 let url;
@@ -151,6 +151,7 @@ describe("redemption attempted", () => {
         setSpendFlag(url.host, true);
         setSpentUrl(url.href, false);
         workflow.__set__("REDEEM_METHOD", "reload");
+        workflow.__set__("SEND_H2C_PARAMS", false);
         let redeemHdrs = beforeSendHeaders(details, url);
         let reqHeaders = redeemHdrs.requestHeaders;
         expect(getSpendFlag(url.host)).toBeFalsy();
@@ -167,7 +168,6 @@ describe("redemption attempted", () => {
         setSpendFlag(url.host, true);
         setSpentUrl(url.href, false);
         workflow.__set__("REDEEM_METHOD", "reload");
-        workflow.__set__("SEND_H2C_PARAMS", true);
         let redeemHdrs = beforeSendHeaders(details, url);
         let reqHeaders = redeemHdrs.requestHeaders;
         expect(getSpendFlag(url.host)).toBeFalsy();

--- a/test/tokens.test.js
+++ b/test/tokens.test.js
@@ -98,26 +98,25 @@ describe("building of redemption headers", () => {
         const chkBinding = reconstructRequestBinding(token.data, token.blind, token.point, host, path);
         expect(type === "Redeem").toBeTruthy();
         // check token data is correct
-        expect(sjcl.bn.fromBits(contents[0]).equals(sjcl.bn.fromBits(token.data))).toBeTruthy();
+        expect(contents[0] == sjcl.codec.base64.fromBits(sjcl.codec.bytes.toBits(token.data))).toBeTruthy();
         // check request binding (hex is easiest way)
-        expect(sjcl.codec.hex.fromBits(sjcl.codec.bytes.toBits(contents[1])) 
-            === sjcl.codec.hex.fromBits(sjcl.codec.bytes.toBits(chkBinding))).toBeTruthy();
+        expect(contents[1] === chkBinding).toBeTruthy();
         
         return contents;
     }
 
     test("header value is built correctly (SEND_H2C_PARAMS = false)", () => {
+        workflow.__set__("SEND_H2C_PARAMS", false);
         const contents = testBuildHeader();
         // Test additional H2C parameters are omitted
         expect(contents.length === 2).toBeTruthy();
     });
 
     test("header value is built correctly (SEND_H2C_PARAMS = true)", () => {
-        workflow.__set__("SEND_H2C_PARAMS", true);
         const contents = testBuildHeader();
         // Test additional H2C parameters are constructed correctly
         expect(contents.length === 3).toBeTruthy();
-        let h2cParams = JSON.parse(sjcl.codec.utf8String.fromBits(sjcl.codec.bytes.toBits(contents[2])));
+        let h2cParams = JSON.parse(atob(contents[2]));
         expect(h2cParams.curve === "p256").toBeTruthy();
         expect(h2cParams.hash === "sha256").toBeTruthy();
         expect(h2cParams.method === "increment").toBeTruthy();


### PR DESCRIPTION
For #73. Redemption data is now an array of base64-encoded values, rather than ArrayBuffers interpreted directly as a string. This reduces the amount of data that we need to send to the server significantly.