### PR TITLE
Optimisations for cryptographic operations and set cfConfig to default

### DIFF
--- a/src/crypto/local.js
+++ b/src/crypto/local.js
@@ -313,22 +313,17 @@ function recomputeComposites(chkM, chkZ, pointG, pointH) {
     let seed = getSeedPRNG(chkM, chkZ, pointG, pointH);
     let shake = createShake256();
     shake.update(seed, "hex");
-    let cM;
-    let cZ;
+    let cM = new sjcl.ecc.pointJac(CURVE); // can only add points in jacobian representation
+    let cZ = new sjcl.ecc.pointJac(CURVE);
     for (let i=0; i<chkM.length; i++) {
         let ci = getShakeScalar(shake);
         let cMi = _scalarMult(ci, chkM[i].point);
         let cZi = _scalarMult(ci, chkZ[i]);
-        if (cM === undefined || cZ === undefined) {
-            cM = cMi;
-            cZ = cZi;
-        } else {
-            cM = cM.toJac().add(cMi).toAffine();
-            cZ = cZ.toJac().add(cZi).toAffine();
-        }
+        cM = cM.add(cMi);
+        cZ = cZ.add(cZi);
     }
 
-    return {M: cM, Z: cZ};
+    return {M: cM.toAffine(), Z: cZ.toAffine()};
 }
 
 /**

--- a/src/ext/config.js
+++ b/src/ext/config.js
@@ -105,4 +105,5 @@ const cfConfig = {
 // Ordering of configs should correspond to value of cf-chl-bypass header
 // i.e. the first config should have "id": 1, the second "id":2, etc.
 const PPConfigs = [exampleConfig,cfConfig];
-let ACTIVE_CONFIG = PPConfigs[0];
+// set CF to be active config by default
+let ACTIVE_CONFIG = PPConfigs[1];

--- a/src/ext/h2c.js
+++ b/src/ext/h2c.js
@@ -234,14 +234,10 @@ function hashAndInc(seed, hash) {
         const digestBits = h.finalize();
         const bytes = sjcl.codec.bytes.fromBits(digestBits);
 
-        // attempt to decompress a point along with valid tags
+        // attempt to decompress a point with a valid tag (don't need to try
+        // 0x03 because this is just the negative version)
         // curve choice is implicit based on active curve parameters
         let point = decompressPoint([2].concat(bytes));
-        if (point !== null) {
-            return point;
-        }
-
-        point = decompressPoint([3].concat(bytes));
         if (point !== null) {
             return point;
         }

--- a/test/beforeRequest.test.js
+++ b/test/beforeRequest.test.js
@@ -1,6 +1,6 @@
 /**
 * Integrations tests for when headers are sent by the browser
-* 
+*
 * @author: Alex Davidson
 */
 import btoa from "btoa";
@@ -70,7 +70,7 @@ function getMock(key) {
     return localStorage[key];
 }
 function setMock(key, value) {
-    localStorage[key] = value; 
+    localStorage[key] = value;
 }
 function clearCachedCommitmentsMock(key) {
     localStorage[CACHED_COMMITMENTS_STRING] = null;
@@ -243,7 +243,7 @@ describe("signing request is cancelled", () => {
 describe("test sending sign requests", () => {
     let validateRespMock = jest.fn();
     workflow.__set__("validateResponse", validateRespMock);
-    
+
     test("incorrect config id", () => {
         function tryRun() {
             workflow.__set__("CONFIG_ID", 3);
@@ -291,8 +291,8 @@ describe("test sending sign requests", () => {
     test("too many tokens does not sign", () => {
         _xhr = mockXHRGood;
         setXHR(_xhr);
-        function run() { 
-            let b = beforeRequest(details, newUrl); 
+        function run() {
+            let b = beforeRequest(details, newUrl);
             let xhr = b.xhr;
             xhr.onreadystatechange();
         };
@@ -308,10 +308,10 @@ describe("test sending sign requests", () => {
     test("correct XHR response triggers validation", () => {
         _xhr = mockXHRGood;
         setXHR(_xhr);
-        function run() { 
+        function run() {
             const request = "";
             const xhrInfo = {newUrl: newUrl, requestBody: "blinded-tokens=" + request, tokens: ""};
-            let xhr = sendXhrSignReq(xhrInfo, newUrl, details.tabId); 
+            let xhr = sendXhrSignReq(xhrInfo, newUrl, details.tabId);
             xhr.responseText = "";
             xhr.onreadystatechange();
         };
@@ -382,12 +382,12 @@ describe("test validating response", () => {
             let before;
             let after;
             let version;
-            function run() { 
+            function run() {
                 let tokens = [];
                 for (let i=0; i<testTokens.length; i++) {
                     tokens[i] = { data: testTokens[i].data, point: sec1DecodePointFromBytes(testTokens[i].point), blind: getBigNumFromBytes(testTokens[i].blind) };
                 }
-                const out = parseRespString(respGoodProof); 
+                const out = parseRespString(respGoodProof);
                 let xhr = validateAndStoreTokens(newUrl, details.tabId, tokens, out.signatures, out.proof, out.version);
                 expect(xhr).toBeTruthy();
                 expect(xhr.send).toBeCalledTimes(1);
@@ -416,12 +416,12 @@ describe("test validating response", () => {
             cacheCommitments("1.0", testG, testH);
             expect(getCachedCommitments("1.0").G === testG).toBeTruthy();
             expect(getCachedCommitments("1.0").H === testH).toBeTruthy();
-            function run() { 
+            function run() {
                 let tokens = [];
                 for (let i=0; i<testTokens.length; i++) {
                     tokens[i] = { token: testTokens[i].data, point: sec1DecodePointFromBytes(testTokens[i].point), blind: getBigNumFromBytes(testTokens[i].blind) };
                 }
-                const out = parseRespString(respGoodProof); 
+                const out = parseRespString(respGoodProof);
                 before = getMock(TOKEN_COUNT_STR);
                 let xhr = validateAndStoreTokens(newUrl, details.tabId, tokens, out.signatures, out.proof, out.version);
                 expect(xhr).toBeFalsy(); // because the commitments are cached, the xhr should not be generated.
@@ -447,12 +447,12 @@ describe("test validating response", () => {
             let version;
             // construct corrupted commitments
             localStorage[CACHED_COMMITMENTS_STRING] = JSON.stringify({ "1.0": {L: testG, H: testH} });
-            function run() { 
+            function run() {
                 let tokens = [];
                 for (let i=0; i<testTokens.length; i++) {
                     tokens[i] = { token: testTokens[i].data, point: sec1DecodePointFromBytes(testTokens[i].point), blind: getBigNumFromBytes(testTokens[i].blind) };
                 }
-                const out = parseRespString(respGoodProof); 
+                const out = parseRespString(respGoodProof);
                 before = getMock(TOKEN_COUNT_STR);
                 let xhr = validateAndStoreTokens(newUrl, details.tabId, tokens, out.signatures, out.proof, out.version);
                 expect(xhr).toBeTruthy();
@@ -484,12 +484,12 @@ describe("test validating response", () => {
             let before;
             let after;
             let version;
-            function run() { 
+            function run() {
                 let tokens = [];
                 for (let i=0; i<testTokens.length; i++) {
                     tokens[i] = { data: testTokens[i].data, point: sec1DecodePointFromBytes(testTokens[i].point), blind: getBigNumFromBytes(testTokens[i].blind) };
                 }
-                const out = parseRespString(respGoodProof); 
+                const out = parseRespString(respGoodProof);
                 let xhr = validateAndStoreTokens(newUrl, details.tabId, tokens, out.signatures, out.proof, out.version);
                 before = getMock(TOKEN_COUNT_STR);
                 xhr.onreadystatechange();
@@ -512,12 +512,12 @@ describe("test validating response", () => {
         test("reloading off after sign", () => {
             let before;
             let after;
-            function run() { 
+            function run() {
                 let tokens = [];
                 for (let i=0; i<testTokens.length; i++) {
                     tokens[i] = { data: testTokens[i].data, point: sec1DecodePointFromBytes(testTokens[i].point), blind: getBigNumFromBytes(testTokens[i].blind) };
                 }
-                const out = parseRespString(respGoodProof); 
+                const out = parseRespString(respGoodProof);
                 let xhr = validateAndStoreTokens(newUrl, details.tabId, tokens, out.signatures, out.proof, out.version);
                 before = getMock(TOKEN_COUNT_STR);
                 xhr.onreadystatechange();
@@ -536,12 +536,12 @@ describe("test validating response", () => {
 
         describe("test parsing errors", () => {
             test("cannot decode point", () => {
-                function run() { 
+                function run() {
                     let tokens = [];
                     for (let i=0; i<testTokens.length; i++) {
                         tokens[i] = { data: testTokens[i].data, point: sec1DecodePointFromBytes(testTokens[i].point), blind: getBigNumFromBytes(testTokens[i].blind) };
                     }
-                    const out = parseRespString("signatures=WyJiYWRfcG9pbnQxIiwgImJhZF9wb2ludDIiXQ=="); 
+                    const out = parseRespString("signatures=WyJiYWRfcG9pbnQxIiwgImJhZF9wb2ludDIiXQ==");
                     let xhr = validateAndStoreTokens(newUrl, details.tabId, tokens, out.signatures, out.proof, out.version);
                     xhr.onreadystatechange();
                 };
@@ -555,12 +555,12 @@ describe("test validating response", () => {
 
             describe("DLEQ formatting errors", () => {
                 test("proof is not JSON", () => {
-                    function run() { 
+                    function run() {
                         let tokens = [];
                         for (let i=0; i<testTokens.length; i++) {
                             tokens[i] = { data: testTokens[i].data, point: sec1DecodePointFromBytes(testTokens[i].point), blind: getBigNumFromBytes(testTokens[i].blind) };
                         }
-                        const out = parseRespString(respBadJson); 
+                        const out = parseRespString(respBadJson);
                         let xhr = validateAndStoreTokens(newUrl, details.tabId, tokens, out.signatures, out.proof, out.version);
                         xhr.onreadystatechange();
                     };
@@ -573,12 +573,12 @@ describe("test validating response", () => {
                 });
 
                 test("proof has bad points", () => {
-                    function run() { 
+                    function run() {
                         let tokens = [];
                         for (let i=0; i<testTokens.length; i++) {
                             tokens[i] = { data: testTokens[i].data, point: sec1DecodePointFromBytes(testTokens[i].point), blind: getBigNumFromBytes(testTokens[i].blind) };
                         }
-                        const out = parseRespString(respBadPoints); 
+                        const out = parseRespString(respBadPoints);
                         let xhr = validateAndStoreTokens(newUrl, details.tabId, tokens, out.signatures, out.proof, out.version);
                         xhr.onreadystatechange();
                     };
@@ -591,12 +591,12 @@ describe("test validating response", () => {
                 });
 
                 test("proof should not verify (bad lengths)", () => {
-                    function run() { 
+                    function run() {
                         let tokens = [];
                         for (let i=0; i<testTokensBadLength.length; i++) {
                             tokens[i] = { data: testTokens[i].data, point: sec1DecodePointFromBytes(testTokens[i].point), blind: getBigNumFromBytes(testTokens[i].blind) };
                         }
-                        const out = parseRespString(respBadProof); 
+                        const out = parseRespString(respBadProof);
                         let xhr = validateAndStoreTokens(newUrl, details.tabId, tokens, out.signatures, out.proof, out.version);
                         xhr.onreadystatechange();
                     };
@@ -614,12 +614,12 @@ describe("test validating response", () => {
                 });
 
                 test("proof should not verify", () => {
-                    function run() { 
+                    function run() {
                         let tokens = [];
                         for (let i=0; i<testTokens.length; i++) {
                             tokens[i] = { data: testTokens[i].data, point: sec1DecodePointFromBytes(testTokens[i].point), blind: getBigNumFromBytes(testTokens[i].blind) };
                         }
-                        const out = parseRespString(respBadProof); 
+                        const out = parseRespString(respBadProof);
                         let xhr = validateAndStoreTokens(newUrl, details.tabId, tokens, out.signatures, out.proof, out.version);
                         xhr.onreadystatechange();
                     };

--- a/test/curve.test.js
+++ b/test/curve.test.js
@@ -43,7 +43,7 @@ beforeEach(() => {
   let settings = getActiveECSettings();
   curve = settings.curve;
   hash = settings.hash;
-  activeCurveParams = ACTIVE_CONFIG["h2c-params"];
+  activeCurveParams = {curve: "p256", hash: "sha256", method: "increment"};
 });
 
 describe('check curve initialisation', () => {


### PR DESCRIPTION
For #78. 
* Fixes h2c to only test points with the tag 0x02 (since 0x03 is just negative version of same point). 
* For computing composites, apply all operations in jacobian format and switch to affine at the end.
* Set active config to cfConfig as default (rather than using exampleConfig as default).
* Removed trailing spaces in beforeRequest.test.js