### PR TITLE
Remove hardcoded SHA256 references

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,4 +12,5 @@ jobs:
       - run: git submodule update --init
       - run: yarn install
       - run: yarn lint
-      - run: yarn all
+      - run: yarn build:all
+      - run: yarn test:all

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -84,7 +84,8 @@
         "signReqHC": true,
         "patternToRegExp": true,
         "ISSUE_ACTION_URLS": true,
-        "LISTENER_URLS": true
+        "LISTENER_URLS": true,
+        "getActiveECSettings": true
     },
     "rules": {
         "new-cap": 0,

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "stringify": "^5.2.0"
   },
   "scripts": {
-    "all": "yarn build:all && yarn test:all",
+    "all": "yarn lint && yarn build:all && yarn test:all",
     "build:all": "yarn build:sjcl && yarn build:ext",
     "test:all": "yarn test:sjcl && yarn test:ext",
     "build:ext": "mkdir -p addon/compiled && google-closure-compiler src/ext/utils.js src/crypto/sjcl/sjcl.js src/ext/config.js src/ext/h2c.js src/crypto/local.js src/ext/tokens.js src/ext/issuance.js src/ext/redemption.js src/ext/browserUtils.js src/ext/background.js src/ext/listeners.js src/crypto/keccak/keccak.js > addon/compiled/bg_compiled.js",

--- a/src/crypto/local.js
+++ b/src/crypto/local.js
@@ -283,7 +283,7 @@ function verifyProof(proofObj, tokens, signatures, commitments) {
     const B = cZ.toJac().add(rM).toAffine();
 
     // Recalculate C' and check if C =?= C'
-    const h = new CURVE_H2C_HASH();
+    const h = new CURVE_H2C_HASH(); // use the h2c hash for convenience
     h.update(sjcl.codec.bytes.toBits(sec1EncodePoint(pointG)));
     h.update(sjcl.codec.bytes.toBits(sec1EncodePoint(pointH)));
     h.update(sjcl.codec.bytes.toBits(sec1EncodePoint(composites.M)));
@@ -363,7 +363,7 @@ function getShakeScalar(shake) {
  * @return {string} hex-encoded PRNG seed
  */
 function getSeedPRNG(chkM, chkZ, pointG, pointH) {
-    const h = new CURVE_H2C_HASH();
+    const h = new CURVE_H2C_HASH(); // we use the h2c hash for convenience
     h.update(encodePointForPRNG(pointG));
     h.update(encodePointForPRNG(pointH));
     for (let i=0; i<chkM.length; i++) {

--- a/src/crypto/local.js
+++ b/src/crypto/local.js
@@ -17,6 +17,7 @@
 /* exported initECSettings */
 /* exported getCurvePoints */
 /* exported getBigNumFromBytes */
+/* exported getActiveECSettings */
 "use strict";
 
 const BATCH_PROOF_PREFIX = "batch-proof=";
@@ -282,7 +283,7 @@ function verifyProof(proofObj, tokens, signatures, commitments) {
     const B = cZ.toJac().add(rM).toAffine();
 
     // Recalculate C' and check if C =?= C'
-    const h = new sjcl.hash.sha256();
+    const h = new CURVE_H2C_HASH();
     h.update(sjcl.codec.bytes.toBits(sec1EncodePoint(pointG)));
     h.update(sjcl.codec.bytes.toBits(sec1EncodePoint(pointH)));
     h.update(sjcl.codec.bytes.toBits(sec1EncodePoint(composites.M)));
@@ -362,14 +363,14 @@ function getShakeScalar(shake) {
  * @return {string} hex-encoded PRNG seed
  */
 function getSeedPRNG(chkM, chkZ, pointG, pointH) {
-    const sha256 = new sjcl.hash.sha256();
-    sha256.update(encodePointForPRNG(pointG));
-    sha256.update(encodePointForPRNG(pointH));
+    const h = new CURVE_H2C_HASH();
+    h.update(encodePointForPRNG(pointG));
+    h.update(encodePointForPRNG(pointH));
     for (let i=0; i<chkM.length; i++) {
-        sha256.update(encodePointForPRNG(chkM[i].point));
-        sha256.update(encodePointForPRNG(chkZ[i]));
+        h.update(encodePointForPRNG(chkM[i].point));
+        h.update(encodePointForPRNG(chkZ[i]));
     }
-    return sjcl.codec.hex.fromBits(sha256.finalize());
+    return sjcl.codec.hex.fromBits(h.finalize());
 }
 
 /**

--- a/src/ext/redemption.js
+++ b/src/ext/redemption.js
@@ -57,8 +57,9 @@ function createRequestBinding(key, data) {
     // the exact bits of the string "hash_request_binding"
     const tagBits = sjcl.codec.utf8String.toBits("hash_request_binding");
     const keyBits = sjcl.codec.bytes.toBits(key);
+    const hash = getActiveECSettings().hash;
 
-    const h = new sjcl.misc.hmac(keyBits, sjcl.hash.sha256);
+    const h = new sjcl.misc.hmac(keyBits, hash);
     h.update(tagBits);
 
     let dataBits = null;
@@ -79,7 +80,8 @@ function createRequestBinding(key, data) {
 function deriveKey(N, token) {
     // the exact bits of the string "hash_derive_key"
     const tagBits = sjcl.codec.hex.toBits("686173685f6465726976655f6b6579");
-    const h = new sjcl.misc.hmac(tagBits, sjcl.hash.sha256);
+    const hash = getActiveECSettings().hash;
+    const h = new sjcl.misc.hmac(tagBits, hash);
 
     const encodedPoint = sec1EncodePoint(N);
     const tokenBits = sjcl.codec.bytes.toBits(token);

--- a/test/tokens.test.js
+++ b/test/tokens.test.js
@@ -102,7 +102,6 @@ describe("building of redemption headers", () => {
         expect(contents[0] == sjcl.codec.base64.fromBits(sjcl.codec.bytes.toBits(token.data))).toBeTruthy();
         // check request binding (hex is easiest way)
         expect(contents[1] === chkBinding).toBeTruthy();
-
         return contents;
     }
 
@@ -113,7 +112,7 @@ describe("building of redemption headers", () => {
         expect(contents.length === 2).toBeTruthy();
     });
 
-    test("header value is built correctly (SEND_H2C_PARAMS = true)", () => {
+    test("header value is built correctly for P256 (SEND_H2C_PARAMS = true)", () => {
         const contents = testBuildHeader();
         // Test additional H2C parameters are constructed correctly
         expect(contents.length === 3).toBeTruthy();


### PR DESCRIPTION
We should use the active hash function from the curve configuration for hashing all information. Also moved `yarn lint` to `yarn all`, and set up separate tasks in circleci for running each command to make errors a bit more granular.