### PR TITLE
Fix some issues with Chrome & sub-resources

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -131,7 +131,20 @@ The name of the header that contains a hostname that is sending the redemption r
 
 #### config["spend-action"]["header-path-name"]
 
-The name of the header that contains a path thatis sending the redemption request.
+The name of the header that contains a path that is sending the redemption
+request.
+
+#### config["spend-action"]["empty-resp-headers"]
+
+If an empty set of response headers is received with the correct status code (as
+defined in `config["spending-restrictions"]["status-code"]`) then this object
+contains an array of strings that correspond to possible ways of acquiring the
+headers. Currently we only support `"direct-request"`, which sends a direct
+request to the same URL with a specific endpoint attached as defined in
+`config["opt-endpoints"]["challenge"]`.
+
+This option was introduced to mitigate problems with Chrome in conjunction with
+sub-resources hosted on separate Cloudflare domains.
 
 ### config["issue-action"]
 
@@ -183,6 +196,10 @@ by the provider. In the case of Cloudflare, this is `"cf_clearance"`.
 A string specifying a domain where users can obtain signed tokens by solving a
 challenge/CAPTCHA. This is helpful to allow users to build up initial stockpiles
 of tokens before they browse.
+
+### config["opt-endpoints"]
+
+Optional endpoints for use by the particular configuration.
 
 ### config["error-codes"]
 

--- a/jest/globals.js
+++ b/jest/globals.js
@@ -55,7 +55,7 @@ window.workflowSet = () => {
     workflow.__set__("setSpendFlag", setSpendFlagMock);
     workflow.__set__("getSpendFlag", getSpendFlagMock);
 
-    workflow.__set__("spentUrlMock", spentUrlMock);
+    workflow.__set__("spentUrl", spentUrlMock);
     workflow.__set__("setSpentUrl", setSpentUrlMock);
     workflow.__set__("getSpentUrl", getSpentUrlMock);
 
@@ -77,14 +77,14 @@ window.workflowSet = () => {
     workflow.__set__("getTarget", getTargetMock);
 
 
-    workflow.__set__("spendIdMock", spendIdMock);
+    workflow.__set__("spendId", spendIdMock);
     workflow.__set__("setSpendId", setSpendIdMock);
     workflow.__set__("getSpendId", getSpendIdMock);
 
-    workflow.__set__("spentTabMock", spentTabMock);
+    workflow.__set__("spentTab", spentTabMock);
     workflow.__set__("pushSpentTab", pushSpentTabMock);
 
-    workflow.__set__("spentHostsMock", spentHostsMock);
+    workflow.__set__("spentHosts", spentHostsMock);
     workflow.__set__("setSpentHosts", setSpentHostsMock);
     workflow.__set__("getSpentHosts", getSpentHostsMock);
 
@@ -122,13 +122,23 @@ window.reloadBrowserTabMock = jest.fn();
 window.validateRespMock = jest.fn();
 
 window.CACHED_COMMITMENTS_STRING = "cached-commitments";
-window.clearCachedCommitmentsMock = () => setMock(CACHED_COMMITMENTS_STRING, null);
-
-window.setSpendFlagMock = (key, value) => setMock(key, value);
-window.getSpendFlagMock = (key) => getMock(key)
-
 window.getMock = (key) => JSON.parse(localStorage.getItem(key));
 window.setMock = (key, value) => localStorage.setItem(key, JSON.stringify(value));
+window.clearCachedCommitmentsMock = () => setMock(CACHED_COMMITMENTS_STRING, null);
+
+// window.setSpendFlagMock = (key, value) => {
+//     if (value) {
+//         localStorage.setItem(key, "true");
+//     } else {
+//         localStorage.removeItem(key);
+//     }
+// };
+// window.getSpendFlagMock = (key) => {
+//     localStorage.getItem(key);
+// }
+window.setSpendFlagMock = (key, value) => setMock(key, value)
+window.getSpendFlagMock = (key) => getMock(key);
+
 window.clearLocalStorage = () => localStorage.clear()
 
 window.bypassTokens = (config_id) => `bypass-tokens-${config_id}`;

--- a/jest/globals.js
+++ b/jest/globals.js
@@ -127,10 +127,10 @@ window.setMock = (key, value) => localStorage.setItem(key, JSON.stringify(value)
 window.CACHED_COMMITMENTS_STRING = "cached-commitments";
 window.clearCachedCommitmentsMock = () => setMock(CACHED_COMMITMENTS_STRING, null);
 
-window.setSpendFlagMock = (key, value) => setMock(key, value)
+window.setSpendFlagMock = (key, value) => setMock(key, value);
 window.getSpendFlagMock = (key) => getMock(key);
 
-window.clearLocalStorage = () => localStorage.clear()
+window.clearLocalStorage = () => localStorage.clear();
 
 window.bypassTokens = (config_id) => `bypass-tokens-${config_id}`;
 window.bypassTokensCount = (config_id) => `bypass-tokens-count-${config_id}`;

--- a/jest/globals.js
+++ b/jest/globals.js
@@ -224,6 +224,23 @@ function mockXHRCommitments() {
 
 window.mockXHRCommitments = mockXHRCommitments;
 
+function mockXHRDirectRequest() {
+    mockXHR(this);
+    this.status = 403;
+    this.readyState = 2;
+    this.HEADERS_RECEIVED = new window.XMLHttpRequest().HEADERS_RECEIVED;
+    this.abort = jest.fn();
+    this.responseHeaders = new Map();
+    this.getResponseHeader = function(name) {
+        return this.responseHeaders[name];
+    };
+    this.setResponseHeader = function(name, value) {
+        this.responseHeaders[name] = value;
+    };
+};
+
+window.mockXHRDirectRequest = mockXHRDirectRequest;
+
 window.setTimeSinceLastResp = (value) => timeSinceLastResp = value;
 
 window.storedTokens = `[{

--- a/jest/globals.js
+++ b/jest/globals.js
@@ -121,21 +121,12 @@ window.updateBrowserTabMock = jest.fn();
 window.reloadBrowserTabMock = jest.fn();
 window.validateRespMock = jest.fn();
 
-window.CACHED_COMMITMENTS_STRING = "cached-commitments";
 window.getMock = (key) => JSON.parse(localStorage.getItem(key));
 window.setMock = (key, value) => localStorage.setItem(key, JSON.stringify(value));
+
+window.CACHED_COMMITMENTS_STRING = "cached-commitments";
 window.clearCachedCommitmentsMock = () => setMock(CACHED_COMMITMENTS_STRING, null);
 
-// window.setSpendFlagMock = (key, value) => {
-//     if (value) {
-//         localStorage.setItem(key, "true");
-//     } else {
-//         localStorage.removeItem(key);
-//     }
-// };
-// window.getSpendFlagMock = (key) => {
-//     localStorage.getItem(key);
-// }
 window.setSpendFlagMock = (key, value) => setMock(key, value)
 window.getSpendFlagMock = (key) => getMock(key);
 

--- a/src/ext/background.js
+++ b/src/ext/background.js
@@ -257,8 +257,8 @@ function processHeaders(details, url) {
 /**
  * Try a direct request against a challenge endpoint if the response headers are
  * empty. This fixes some strange behaviour with CF sites and Chrome.
- * @param {Object} details
- * @param {URL} url
+ * @param {Object} details Original request details
+ * @param {URL} url Origin URL
  * @return {boolean} indicates whether an XHR was launched
  */
 function tryRequestChallenge(details, url) {

--- a/src/ext/background.js
+++ b/src/ext/background.js
@@ -330,7 +330,7 @@ function beforeSendHeaders(request, url) {
                 .map((redeemUrl) => patternToRegExp(redeemUrl))
                 .some((re) => reqUrl.match(re));
 
-            setSpendFlag(url.host, null);
+            setSpendFlag(host, null);
 
             if (countStoredTokens() > 0 && isRedeemUrl) {
                 const tokenToSpend = GetTokenForSpend();
@@ -481,10 +481,11 @@ function handleMessage(request, sender, sendResponse) {
  * @param {string} host String corresponding to host
  */
 function incrementSpentHost(host) {
-    if (getSpentHosts(host) === undefined) {
-        setSpentHosts(host, 0);
+    let n = getSpentHosts(host);
+    if (n === undefined) {
+        n = 0;
     }
-    setSpentHosts(host, getSpentHosts(host) + 1);
+    setSpentHosts(host, n + 1);
 }
 
 /**
@@ -493,7 +494,8 @@ function incrementSpentHost(host) {
  * @return {boolean}
  */
 function checkMaxSpend(host) {
-    if (getSpentHosts(host) === undefined || getSpentHosts(host) < spendMax() || spendMax() === undefined) {
+    const n = getSpentHosts(host);
+    if (n === undefined || n < spendMax() || spendMax() === undefined) {
         return false;
     }
     return true;

--- a/src/ext/background.js
+++ b/src/ext/background.js
@@ -77,6 +77,8 @@ const issueActionUrls = () => activeConfig()["issue-action"]["urls"];
 const reloadOnSign = () => activeConfig()["issue-action"]["sign-reload"];
 const signResponseFMT = () => activeConfig()["issue-action"]["sign-resp-format"];
 const tokensPerRequest = () => activeConfig()["issue-action"]["tokens-per-request"];
+const optEndpoints = () => activeConfig()["opt-endpoints"];
+const emptyRespHeaders = () => activeConfig()["spend-action"]["empty-resp-headers"];
 
 /* Config variables that are reset in setConfig() depending on the header value that is received (see config.js) */
 initECSettings(h2cParams());
@@ -210,12 +212,13 @@ function validRedirect(oldUrl, redirectUrl) {
  * @return {boolean}
  */
 function processHeaders(details, url) {
+    const ret = {attempted: false, xhr: false, favicon: false};
     // We're not interested in running this logic for favicons
     if (isFaviconUrl(url.href)) {
-        return false;
+        ret.favicon = true;
+        return ret;
     }
 
-    let activated = false;
     for (let i = 0; i < details.responseHeaders.length; i++) {
         const header = details.responseHeaders[i];
         if (header.name.toLowerCase() === CHL_BYPASS_RESPONSE) {
@@ -233,13 +236,62 @@ function processHeaders(details, url) {
 
         // correct status code with the right header indicates a bypassable Cloudflare CAPTCHA
         if (isBypassHeader(header) && spendStatusCode().includes(details.statusCode)) {
-            activated = true;
+            ret.attempted = decideRedeem(details, url);
+            break;
         }
     }
 
-    // If we have tokens to spend, cancel the request and pass execution over to the token handler.
+    if (details.responseHeaders.length === 0
+        && spendStatusCode().includes(details.statusCode)
+        && emptyRespHeaders().includes("direct-request")) {
+        // There is some weirdness with Chrome whereby some resources return empty
+        // responseHeaders but where a spend *should* occur. If this happens then we
+        // send a direct request to an endpoint that determines whether a CAPTCHA
+        // page is shown via XHR.
+        ret.xhr = tryRequestChallenge(details, url, ret);
+    }
+
+    return ret;
+}
+
+/**
+ * Try a direct request against a challenge endpoint if the response headers are
+ * empty. This fixes some strange behaviour with CF sites and Chrome.
+ * @param {Object} details
+ * @param {URL} url
+ * @return {boolean} indicates whether an XHR was launched
+ */
+function tryRequestChallenge(details, url) {
+    const xhr = new XMLHttpRequest();
+    xhr.onreadystatechange = function() {
+        // We return a boolean for testing purposes
+        let xhrRet = false;
+        if (this.readyState === this.HEADERS_RECEIVED) {
+            if (spendStatusCode().includes(xhr.status) && xhr.getResponseHeader(CHL_BYPASS_SUPPORT) === CONFIG_ID) {
+                // don't return anything here because it is async
+                decideRedeem(details, url);
+                xhr.abort();
+                xhrRet = true;
+            }
+            xhr.abort();
+        }
+        return xhrRet;
+    };
+    const challengePath = optEndpoints().challenge || "";
+    xhr.open("GET", url.origin + challengePath, true);
+    xhr.send();
+    return xhr;
+}
+
+/**
+ * Decides whether to redeem a token for the given URL
+ * @param {Object} details Response details
+ * @param {URL} url URL object for possible redemption
+ * @return {boolean}
+ */
+function decideRedeem(details, url) {
     let attempted = false;
-    if (activated && !getSpentUrl(url.href)) {
+    if (!spentUrl[url.href]) {
         const count = countStoredTokens();
         if (doRedeem()) {
             if (count > 0 && !url.host.includes(chlCaptchaDomain())) {
@@ -268,7 +320,6 @@ function processHeaders(details, url) {
  */
 function beforeSendHeaders(request, url) {
     // Cancel if we don't have a token to spend
-
     const reqUrl = url.href;
     const host = url.host;
 

--- a/src/ext/background.js
+++ b/src/ext/background.js
@@ -270,7 +270,6 @@ function tryRequestChallenge(details, url) {
             if (spendStatusCode().includes(xhr.status) && xhr.getResponseHeader(CHL_BYPASS_SUPPORT) === CONFIG_ID) {
                 // don't return anything here because it is async
                 decideRedeem(details, url);
-                xhr.abort();
                 xhrRet = true;
             }
             xhr.abort();

--- a/src/ext/browserUtils.js
+++ b/src/ext/browserUtils.js
@@ -211,7 +211,10 @@ function updateBrowserTab(id, targetUrl) {
  * @param {Number} id
  */
 function reloadBrowserTab(id) {
-    chrome.tabs.reload(id);
+    if (id >= 0) {
+        // if id < 0 this caused error messages
+        chrome.tabs.reload(id);
+    }
 }
 
 /**

--- a/src/ext/config.js
+++ b/src/ext/config.js
@@ -24,7 +24,7 @@ function exampleConfig() {
         "dev": true, // sets whether the configuration should only be used in development
         "sign": true, // sets whether tokens should be sent for signing
         "redeem": true, // sets whether tokens should be sent for redemption
-        "max-spends": 3, // for each host header, sets the max number of tokens that will be spent, undefined for unlimited
+        "max-spends": 1, // for each host header, sets the max number of tokens that will be spent, undefined for unlimited
         "max-tokens": 10, // max number of tokens held by the extension
         "var-reset": true, // whether variables should be reset after time limit expires
         "var-reset-ms": 100, // variable reset time limit
@@ -92,7 +92,6 @@ function PPConfigs() {
     cfConfig["send-h2c-params"] = true;
     cfConfig["opt-endpoints"].challenge = "/cdn-cgi/challenge";
     cfConfig["spend-action"]["empty-resp-headers"] = ["direct-request"];
-    cfConfig["max-spends"] = 1; // this used to be 3 but lead to more spends than necessary so I've reduced it to 1 and it doesn't seem to have an impact
 
     // The configuration used by hcaptcha
     const hcConfig = exampleConfig();

--- a/src/ext/config.js
+++ b/src/ext/config.js
@@ -44,6 +44,7 @@ function exampleConfig() {
             "header-name": "challenge-bypass-token", // name of header for sending redemption token
             "header-host-name": "challenge-bypass-host", // needed for no-reload method
             "header-path-name": "challenge-bypass-path", // needed for no-reload method
+            "empty-resp-headers": [], // if a HTTP response returns with no headers, specify what action to take; default is no action, also support "direct-request"
         },
         "issue-action": {
             "urls": ["<all_urls>"],
@@ -56,6 +57,7 @@ function exampleConfig() {
             "clearance-cookie": "", // name of clearance cookies for checking (cookies that are optionally acquired after redemption occurs)
         },
         "captcha-domain": "", // optional domain for acquiring tokens
+        "opt-endpoints": {}, // optional endpoints for integration-specific operations
         "error-codes": {
             "verify-error": "5", // error code sent by server for verification error
             "connection-error": "6", // error code sent by server for connection error
@@ -88,6 +90,9 @@ function PPConfigs() {
     cfConfig.cookies["clearance-cookie"] = "cf_clearance";
     cfConfig["captcha-domain"] = "captcha.website";
     cfConfig["send-h2c-params"] = true;
+    cfConfig["opt-endpoints"].challenge = "/cdn-cgi/challenge";
+    cfConfig["spend-action"]["empty-resp-headers"] = ["direct-request"];
+    cfConfig["max-spends"] = 1; // this used to be 3 but lead to more spends than necessary so I've reduced it to 1 and it doesn't seem to have an impact
 
     // The configuration used by hcaptcha
     const hcConfig = exampleConfig();
@@ -106,6 +111,7 @@ function PPConfigs() {
     hcConfig.cookies["clearance-cookie"] = "hc_clearance";
     hcConfig["captcha-domain"] = "hcaptcha.com";
     hcConfig["send-h2c-params"] = true;
+
     // Ordering of configs should correspond to value of cf-chl-bypass header
     // i.e. the first config should have "id": 1, the second "id":2, etc.
     return [exampleConfig(), cfConfig, hcConfig];

--- a/test/.eslintrc.tests.json
+++ b/test/.eslintrc.tests.json
@@ -41,6 +41,7 @@
         "mockXHRGood": true,
         "mockXHRBadReadyState": true,
         "mockXHRBadStatus": true,
+        "mockXHRDirectRequest": true,
         "setSpentHostsMock": true,
         "clearCachedCommitmentsMock": true,
         "testDevG": true,

--- a/test/headersReceived.test.js
+++ b/test/headersReceived.test.js
@@ -36,196 +36,186 @@ const setNoTokens = (configId) => {
  */
 
 each(PPConfigs().filter((config) => config.id > 0).map((config) => [config.id]))
-.describe("CONFIG_ID = %i", (configId) => {
-    beforeEach(() => {
-        clearLocalStorage();
-        // Override global setting
-        workflow.__set__("attemptRedeem", () => true);
-        workflow.__set__("CONFIG_ID", configId);
-        workflow.__set__("spendActionUrls", () => [LISTENER_URLS]);
-        workflow.__set__("issueActionUrls", () => [LISTENER_URLS]);
-        setMock(bypassTokens(configId), storedTokens);
-        setMock(bypassTokensCount(configId), 2);
-    });
-
-    describe("ensure that errors are handled properly", () => {
-        const url = new URL(EXAMPLE_HREF);
-        test("connection error", () => {
-            localStorage.setItem("data", "some token");
-
-            function processConnError() {
-                const details = {
-                    responseHeaders: [{name: CHL_BYPASS_RESPONSE, value: chlConnectionError()}],
-                };
-                processHeaders(details, url);
-            }
-
-            expect(processConnError).toThrowError(`error code: ${chlConnectionError()}`);
-            expect(localStorage.getItem("data")).toBeTruthy();
-        });
-        test("verification error", () => {
-            function processVerifyError() {
-                const details = {
-                    responseHeaders: [{name: CHL_BYPASS_RESPONSE, value: chlVerificationError()}],
-                };
-                processHeaders(details, url);
-            }
-
-            expect(processVerifyError).toThrowError(`error code: ${chlVerificationError()}`);
-            expect(localStorage.getItem("data")).toBeFalsy();
-        });
-    });
-
-    describe("check bypass header is working", () => {
-        let found;
+    .describe("CONFIG_ID = %i", (configId) => {
         beforeEach(() => {
-            found = false;
+            clearLocalStorage();
+            // Override global setting
+            workflow.__set__("attemptRedeem", () => true);
+            workflow.__set__("CONFIG_ID", configId);
+            workflow.__set__("spendActionUrls", () => [LISTENER_URLS]);
+            workflow.__set__("issueActionUrls", () => [LISTENER_URLS]);
+            setMock(bypassTokens(configId), storedTokens);
+            setMock(bypassTokensCount(configId), 2);
         });
 
-        test("header is valid", () => {
-            const header = {name: CHL_BYPASS_SUPPORT, value: `${configId}`};
-            found = isBypassHeader(header);
-            expect(found).toBeTruthy();
-        });
-        test("header is invalid value", () => {
-            const header = {name: CHL_BYPASS_SUPPORT, value: "0"};
-            found = isBypassHeader(header);
-            expect(found).toBeFalsy();
-        });
-        test("header is invalid name", () => {
-            const header = {name: "Different-header-name", value: `${configId}`};
-            found = isBypassHeader(header);
-            expect(found).toBeFalsy();
-        });
-        test("config is reset if ID changes", () => {
-            const oldConfigId = configId + 1;
-            workflow.__with__({CONFIG_ID: oldConfigId})(() => {
-                setMock(bypassTokensCount(oldConfigId), 10);
-                const header = {name: CHL_BYPASS_SUPPORT, value: `${configId}`};
-                const oldCount = getMock(bypassTokensCount(oldConfigId));
-                found = isBypassHeader(header);
-                expect(found).toBeTruthy();
-                expect(oldCount === getMock(bypassTokensCount(configId))).toBeFalsy();
-                expect(updateIconMock).toHaveBeenCalledTimes(1);
+        describe("ensure that errors are handled properly", () => {
+            const url = new URL(EXAMPLE_HREF);
+            test("connection error", () => {
+                localStorage.setItem("data", "some token");
+
+                function processConnError() {
+                    const details = {
+                        responseHeaders: [{name: CHL_BYPASS_RESPONSE, value: chlConnectionError()}],
+                    };
+                    processHeaders(details, url);
+                }
+
+                expect(processConnError).toThrowError(`error code: ${chlConnectionError()}`);
+                expect(localStorage.getItem("data")).toBeTruthy();
+            });
+            test("verification error", () => {
+                function processVerifyError() {
+                    const details = {
+                        responseHeaders: [{name: CHL_BYPASS_RESPONSE, value: chlVerificationError()}],
+                    };
+                    processHeaders(details, url);
+                }
+
+                expect(processVerifyError).toThrowError(`error code: ${chlVerificationError()}`);
+                expect(localStorage.getItem("data")).toBeFalsy();
             });
         });
-        test("config is not reset if ID does not change", () => {
-            const oldConfigId = configId;
-            workflow.__with__({CONFIG_ID: oldConfigId})(() => {
-                setMock(bypassTokensCount(oldConfigId), 10);
+
+        describe("check bypass header is working", () => {
+            let found;
+            beforeEach(() => {
+                found = false;
+            });
+
+            test("header is valid", () => {
                 const header = {name: CHL_BYPASS_SUPPORT, value: `${configId}`};
-                const oldCount = getMock(bypassTokensCount(oldConfigId));
                 found = isBypassHeader(header);
                 expect(found).toBeTruthy();
-                expect(oldCount === getMock(bypassTokensCount(configId))).toBeTruthy();
-                expect(updateIconMock).toHaveBeenCalledTimes(0);
+            });
+            test("header is invalid value", () => {
+                const header = {name: CHL_BYPASS_SUPPORT, value: "0"};
+                found = isBypassHeader(header);
+                expect(found).toBeFalsy();
+            });
+            test("header is invalid name", () => {
+                const header = {name: "Different-header-name", value: `${configId}`};
+                found = isBypassHeader(header);
+                expect(found).toBeFalsy();
+            });
+            test("config is reset if ID changes", () => {
+                const oldConfigId = configId + 1;
+                workflow.__with__({CONFIG_ID: oldConfigId})(() => {
+                    setMock(bypassTokensCount(oldConfigId), 10);
+                    const header = {name: CHL_BYPASS_SUPPORT, value: `${configId}`};
+                    const oldCount = getMock(bypassTokensCount(oldConfigId));
+                    found = isBypassHeader(header);
+                    expect(found).toBeTruthy();
+                    expect(oldCount === getMock(bypassTokensCount(configId))).toBeFalsy();
+                    expect(updateIconMock).toHaveBeenCalledTimes(1);
+                });
+            });
+            test("config is not reset if ID does not change", () => {
+                const oldConfigId = configId;
+                workflow.__with__({CONFIG_ID: oldConfigId})(() => {
+                    setMock(bypassTokensCount(oldConfigId), 10);
+                    const header = {name: CHL_BYPASS_SUPPORT, value: `${configId}`};
+                    const oldCount = getMock(bypassTokensCount(oldConfigId));
+                    found = isBypassHeader(header);
+                    expect(found).toBeTruthy();
+                    expect(oldCount === getMock(bypassTokensCount(configId))).toBeTruthy();
+                    expect(updateIconMock).toHaveBeenCalledTimes(0);
+                });
             });
         });
-    });
 
-    describe("check redemption attempt conditions", () => {
-        let url;
-        let details;
-        let header;
-        beforeEach(() => {
-            header = {name: CHL_BYPASS_SUPPORT, value: configId};
-            details = {
-                statusCode: spendStatusCode()[0],
-                responseHeaders: [header],
-            };
-            url = new URL("http://www.example.com");
-        });
+        describe("check redemption attempt conditions", () => {
+            let url;
+            let details;
+            let header;
+            beforeEach(() => {
+                header = {name: CHL_BYPASS_SUPPORT, value: configId};
+                details = {
+                    statusCode: spendStatusCode()[0],
+                    responseHeaders: [header],
+                };
+                url = new URL("http://www.example.com");
+            });
 
-        test("check that favicon urls are ignored", () => {
-            url = new URL("https://example.com/favicon.ico");
-            expect(isFaviconUrl(url.href)).toBeTruthy();
-            const ret = processHeaders(details, url);
-            expect(ret.attempted).toBeFalsy();
-            expect(ret.xhr).toBeFalsy();
-            expect(ret.favicon).toBeTruthy();
-            expect(updateIconMock).toBeCalledTimes(0);
-        });
+            test("check that favicon urls are ignored", () => {
+                url = new URL("https://example.com/favicon.ico");
+                expect(isFaviconUrl(url.href)).toBeTruthy();
+                const ret = processHeaders(details, url);
+                expect(ret.attempted).toBeFalsy();
+                expect(ret.xhr).toBeFalsy();
+                expect(ret.favicon).toBeTruthy();
+                expect(updateIconMock).toBeCalledTimes(0);
+            });
 
-        test("check that redemption is not fired on CAPTCHA domain", () => {
-            url = new URL(`https://${chlCaptchaDomain()}`);
-            const ret = processHeaders(details, url);
-            expect(ret.attempted).toBeFalsy();
-            expect(ret.xhr).toBeFalsy();
-            expect(ret.favicon).toBeFalsy();
-        });
+            test("check that redemption is not fired on CAPTCHA domain", () => {
+                url = new URL(`https://${chlCaptchaDomain()}`);
+                const ret = processHeaders(details, url);
+                expect(ret.attempted).toBeFalsy();
+                expect(ret.xhr).toBeFalsy();
+                expect(ret.favicon).toBeFalsy();
+            });
 
-        test("redemption is attempted on general domains", () => {
-            const ret = processHeaders(details, url);
-            expect(ret.attempted).toBeTruthy();
-            expect(ret.xhr).toBeFalsy();
-            expect(ret.favicon).toBeFalsy();
-            expect(updateIconMock).toBeCalledTimes(1);
-        });
+            test("redemption is attempted on general domains", () => {
+                const ret = processHeaders(details, url);
+                expect(ret.attempted).toBeTruthy();
+                expect(ret.xhr).toBeFalsy();
+                expect(ret.favicon).toBeFalsy();
+                expect(updateIconMock).toBeCalledTimes(1);
+            });
 
-        test("not fired if status code != spendStatusCode()[0]", () => {
-            details.statusCode = 418;
-            const ret = processHeaders(details, url);
-            expect(ret.attempted).toBeFalsy();
-            expect(ret.xhr).toBeFalsy();
-            expect(ret.favicon).toBeFalsy();
-        });
+            test("not fired if status code != spendStatusCode()[0]", () => {
+                details.statusCode = 418;
+                const ret = processHeaders(details, url);
+                expect(ret.attempted).toBeFalsy();
+                expect(ret.xhr).toBeFalsy();
+                expect(ret.favicon).toBeFalsy();
+            });
 
-        test("if count is 0 update icon", () => {
-            setNoTokens(configId);
-            processHeaders(details, url);
-            expect(updateIconMock).toBeCalledTimes(2);
-        });
+            test("if count is 0 update icon", () => {
+                setNoTokens(configId);
+                processHeaders(details, url);
+                expect(updateIconMock).toBeCalledTimes(2);
+            });
 
-        describe("setting of readySign", () => {
-            describe("signing enabled", () => {
-                beforeEach(() => {
-                    workflow.__set__("doSign", () => true);
-                    workflow.__set__("readySign", false);
-                });
+            describe("setting of readySign", () => {
+                describe("signing enabled", () => {
+                    beforeEach(() => {
+                        workflow.__set__("doSign", () => true);
+                        workflow.__set__("readySign", false);
+                    });
 
-                test("no tokens", () => {
-                    setNoTokens(configId);
-                    const ret = processHeaders(details, url);
-                    expect(ret.attempted).toBeFalsy();
-                    expect(ret.xhr).toBeFalsy();
-                    expect(ret.favicon).toBeFalsy();
-                    const readySign = workflow.__get__("readySign");
-                    expect(readySign).toBeTruthy();
-                    expect(updateIconMock).toBeCalledWith("!");
-                });
+                    test("no tokens", () => {
+                        setNoTokens(configId);
+                        const ret = processHeaders(details, url);
+                        expect(ret.attempted).toBeFalsy();
+                        expect(ret.xhr).toBeFalsy();
+                        expect(ret.favicon).toBeFalsy();
+                        const readySign = workflow.__get__("readySign");
+                        expect(readySign).toBeTruthy();
+                        expect(updateIconMock).toBeCalledWith("!");
+                    });
 
-                test("not activated", () => {
-                    header = {name: "Different-header-name", value: configId};
-                    details.responseHeaders = [header];
-                    const ret = processHeaders(details, url);
-                    expect(ret.attempted).toBeFalsy();
-                    expect(ret.xhr).toBeFalsy();
-                    expect(ret.favicon).toBeFalsy();
-                    const readySign = workflow.__get__("readySign");
-                    expect(readySign).toBeFalsy();
-                });
+                    test("not activated", () => {
+                        header = {name: "Different-header-name", value: configId};
+                        details.responseHeaders = [header];
+                        const ret = processHeaders(details, url);
+                        expect(ret.attempted).toBeFalsy();
+                        expect(ret.xhr).toBeFalsy();
+                        expect(ret.favicon).toBeFalsy();
+                        const readySign = workflow.__get__("readySign");
+                        expect(readySign).toBeFalsy();
+                    });
 
-                test("tokens > 0", () => {
-                    const ret = processHeaders(details, url);
-                    expect(ret.attempted).toBeTruthy();
-                    expect(ret.xhr).toBeFalsy();
-                    expect(ret.favicon).toBeFalsy();
-                    const readySign = workflow.__get__("readySign");
-                    expect(readySign).toBeFalsy();
-                });
+                    test("tokens > 0", () => {
+                        const ret = processHeaders(details, url);
+                        expect(ret.attempted).toBeTruthy();
+                        expect(ret.xhr).toBeFalsy();
+                        expect(ret.favicon).toBeFalsy();
+                        const readySign = workflow.__get__("readySign");
+                        expect(readySign).toBeFalsy();
+                    });
 
-                test("tokens > 0 but captcha.website", () => {
-                    url = new URL(`https://${chlCaptchaDomain()}`);
-                    const ret = processHeaders(details, url);
-                    expect(ret.attempted).toBeFalsy();
-                    expect(ret.xhr).toBeFalsy();
-                    expect(ret.favicon).toBeFalsy();
-                    const readySign = workflow.__get__("readySign");
-                    expect(readySign).toBeTruthy();
-                });
-
-                test("redemption off", () => {
-                    workflow.__with__({doRedeem: () => false})(() => {
+                    test("tokens > 0 but captcha.website", () => {
+                        url = new URL(`https://${chlCaptchaDomain()}`);
                         const ret = processHeaders(details, url);
                         expect(ret.attempted).toBeFalsy();
                         expect(ret.xhr).toBeFalsy();
@@ -233,25 +223,35 @@ each(PPConfigs().filter((config) => config.id > 0).map((config) => [config.id]))
                         const readySign = workflow.__get__("readySign");
                         expect(readySign).toBeTruthy();
                     });
-                });
-            });
 
-            describe("signing disabled", () => {
-                test("signing is not activated", () => {
-                    workflow.__with__({readySign: false, doSign: () => false})(() => {
-                        header = {name: "Different-header-name", value: configId};
-                        details.responseHeaders = [header];
-                        const ret = processHeaders(details, url);
-                        expect(ret.attempted).toBeFalsy();
-                        expect(ret.xhr).toBeFalsy();
-                        expect(ret.favicon).toBeFalsy();
-                        expect(workflow.__get__("readySign")).toBeFalsy();
+                    test("redemption off", () => {
+                        workflow.__with__({doRedeem: () => false})(() => {
+                            const ret = processHeaders(details, url);
+                            expect(ret.attempted).toBeFalsy();
+                            expect(ret.xhr).toBeFalsy();
+                            expect(ret.favicon).toBeFalsy();
+                            const readySign = workflow.__get__("readySign");
+                            expect(readySign).toBeTruthy();
+                        });
+                    });
+                });
+
+                describe("signing disabled", () => {
+                    test("signing is not activated", () => {
+                        workflow.__with__({readySign: false, doSign: () => false})(() => {
+                            header = {name: "Different-header-name", value: configId};
+                            details.responseHeaders = [header];
+                            const ret = processHeaders(details, url);
+                            expect(ret.attempted).toBeFalsy();
+                            expect(ret.xhr).toBeFalsy();
+                            expect(ret.favicon).toBeFalsy();
+                            expect(workflow.__get__("readySign")).toBeFalsy();
+                        });
                     });
                 });
             });
         });
     });
-});
 
 describe("xhr for empty response headers", () => {
     const details = {

--- a/test/redemption.test.js
+++ b/test/redemption.test.js
@@ -37,6 +37,7 @@ each(PPConfigs().filter((config) => config.id > 0).map((config) => [config.id]))
             url = new URL(EXAMPLE_HREF);
             resetVars();
             resetSpendVars();
+            setSpendFlagMock(url.host, null);
             workflow.__set__("CONFIG_ID", configId);
             workflow.__set__("spendActionUrls", () => [LISTENER_URLS]);
         });
@@ -129,13 +130,18 @@ each(PPConfigs().filter((config) => config.id > 0).map((config) => [config.id]))
                 expect(getSpendFlagMock(url.host)).toBeNull();
             });
         });
+
         describe("redemption attempted", () => {
             test(`redemption header added (SEND_H2C_PARAMS = false)`, () => {
                 workflow.__with__({sendH2CParams: () => false})(() => {
+                    setSpentHostsMock(url.host, 0);
                     setSpendFlagMock(url.host, true);
                     setSpentUrlMock(url.href, false);
-                    const redeemHdrs = beforeSendHeaders(details, url);
-                    const reqHeaders = redeemHdrs.requestHeaders;
+                    let reqHeaders;
+                    expect(() => {
+                        const redeemHdrs = beforeSendHeaders(details, url);
+                        reqHeaders = redeemHdrs.requestHeaders;
+                    }).not.toThrow();
                     expect(getSpendFlagMock(url.host)).toBeNull();
                     expect(getSpendIdMock([details.requestId])).toBeTruthy();
                     expect(getSpentUrlMock(url.href)).toBeTruthy();
@@ -148,10 +154,14 @@ each(PPConfigs().filter((config) => config.id > 0).map((config) => [config.id]))
             });
             test(`redemption header added (SEND_H2C_PARAMS = true)`, () => {
                 workflow.__with__({sendH2CParams: () => true})(() => {
+                    setSpentHostsMock(url.host, 0);
                     setSpendFlagMock(url.host, true);
                     setSpentUrlMock(url.href, false);
-                    const redeemHdrs = beforeSendHeaders(details, url);
-                    const reqHeaders = redeemHdrs.requestHeaders;
+                    let reqHeaders;
+                    expect(() => {
+                        const redeemHdrs = beforeSendHeaders(details, url);
+                        reqHeaders = redeemHdrs.requestHeaders;
+                    }).not.toThrow();
                     expect(getSpendFlagMock(url.host)).toBeNull();
                     expect(getSpendIdMock([details.requestId])).toBeTruthy();
                     expect(getSpentUrlMock([url.href])).toBeTruthy();


### PR DESCRIPTION
Using Privacy Pass in Chrome sometimes failed to load certain resources because the responseHeaders returned in the webRequest API were empty. This meant that no token was ever spent for them. This was a problem for some CF websites, particularly if sub-resources were stored off the initial requested domain.

This change provides a fix by sending an async request to a CF endpoint for any resource where this occurs and sets a spend flag if the website returns with the correct header and status code for the active configuration. I've added some config options for doing this that are off by default (but on for the CF config).

Other changes:
* fixed a config mix-up for naming verification & connection errors
* only reload tabs with id >= 0
* remove SPEND_IFRAME tests because that config option is not used anymore