### PR TITLE
Consistent SSWU implementation with IETF draft

### DIFF
--- a/test/curve.test.js
+++ b/test/curve.test.js
@@ -178,7 +178,7 @@ describe("hashing to p256", () => {
         }
     });
 
-    describe("point at infinity", () => {
+    describe("exceptional cases", () => {
         const params = getCurveParams(sjcl.ecc.curves.c256);
         const testVectors = [
             {

--- a/test/curve.test.js
+++ b/test/curve.test.js
@@ -10,7 +10,6 @@ const h2Curve = workflow.__get__("h2Curve");
 const h2Base = workflow.__get__("h2Base");
 const simplifiedSWU = workflow.__get__("simplifiedSWU");
 const hashAndInc = workflow.__get__("hashAndInc");
-const jacobianSWUP256 = workflow.__get__("jacobianSWUP256");
 const ACTIVE_CONFIG = workflow.__get__("ACTIVE_CONFIG");
 const setConfig = workflow.__get__("setConfig");
 const getActiveECSettings = workflow.__get__("getActiveECSettings");
@@ -113,23 +112,63 @@ describe("check curve parameters are correct", () => {
 describe("hashing to p256", () => {
     const byteLength = 32;
     const wordLength = byteLength / 4;
-    test("affine", () => {
-        for (let i=0; i<10; i++) {
-            const random = sjcl.random.randomWords(wordLength, 10);
-            const rndBits = sjcl.codec.bytes.toBits(random);
-            const runH2C = function run() {
-                simplifiedSWU(rndBits, curve, hash, 0);
-            };
-            expect(runH2C).not.toThrowError();
+
+    describe("affine test vectors", () => {
+        const testVectors = [
+            [],
+            [0],
+            [0xff],
+            [0xff, 0x00, 0x11, 0x22, 0x33, 0x44, 0x11, 0x22, 0x33, 0x44, 0x11, 0x22,
+                0x33, 0x44, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x55, 0x66,
+                0x77, 0x88, 0x55, 0x66, 0x77, 0x88, 0x55, 0x66, 0x77, 0x88],
+        ];
+        const expected = [
+            {
+                t: "f4bf932eec234a64399ba0f4aa4c07817bbf3d5e23b9efcf004631fb9d1ef60a",
+                X: "0b05ff942eaf3c02a8d3d1bc1c3df582849dde7fef1e3030465605ca47be8695",
+                Y: "ca48b4a5112d113b222d3677ef0aa24cd65353ab51308cab871a3d3f2a8809e6",
+            },
+            {
+                t: "928fd78ea9288b1849d9129a923a67ab925ba22fd8ab6d20ecfd1bbb27972ae5",
+                X: "ebe93781c6da1f2e8c4f413ba513cc2e507b1cade03307cd11c6ce08427a2597",
+                Y: "5fb12aa35a6336df78b5adcdabd264556b2c1150431c0849d99dac80b9f53271",
+            },
+            {
+                t: "f12ed3708b3e0ad507b1d562b4236b3c00232140b61e1a8fdcc244a88d5f3b07",
+                X: "d757d33753253ae290aa98071fd8ee5087617e8ce57542a5f4e1dcaddbd4cfed",
+                Y: "eef18a2a6b6fdbc5d17c95627493d0d8308a042538ceaa2394bac9ee352d7b0e",
+            },
+            {
+                t: "7128b7ac4f9506e36831804ede26275e0b8f14491c45ca3eb172e179ebb5bb67",
+                X: "d38c479f260c3cce0d3a0442fe3378fd7af61750984f3d30963a9e6a553f5777",
+                Y: "51a3742c76246a7b293434b6133e3ee21db3c53eacd666be51c24ddf64694571",
+            },
+        ];
+        for (let i=0; i<testVectors.length; i++) {
+            test(`i=${i}`, () => {
+                const label = "H2C-P256-SHA256-SSWU-";
+                workflow.__set__("H2C_SEED", label); // use label from the draft
+                const alpha = sjcl.codec.bytes.toBits(testVectors[i]);
+
+                // check that h2base is consistent
+                const t = h2Base(alpha, curve, hash, label);
+                expect(sjcl.codec.hex.fromBits(t.toBits())).toEqual(expected[i].t);
+
+                // check that sswu in full is consistent
+                const point = simplifiedSWU(alpha, curve, hash);
+                expect(sjcl.codec.hex.fromBits(point.x.toBits())).toEqual(expected[i].X);
+                expect(sjcl.codec.hex.fromBits(point.y.toBits())).toEqual(expected[i].Y);
+                expect(point.isValid()).toBeTruthy();
+            });
         }
     });
 
-    test("jacobian", () => {
+    test("affine random", () => {
         for (let i=0; i<10; i++) {
             const random = sjcl.random.randomWords(wordLength, 10);
             const rndBits = sjcl.codec.bytes.toBits(random);
             const runH2C = function run() {
-                simplifiedSWU(rndBits, curve, hash, 1);
+                simplifiedSWU(rndBits, curve, hash);
             };
             expect(runH2C).not.toThrowError();
         }
@@ -167,26 +206,6 @@ describe("hashing to p256", () => {
             };
             expect(runH2C).not.toThrowError();
         }
-    });
-
-    describe("point at infinity", () => {
-        test("t=0", () => {
-            const params = getInputParams(0);
-            const pJac = jacobianSWUP256(curve, params.baseField, params.A, params.B, params.t);
-            expect(pJac.z.equals(new params.baseField(0))).toBeTruthy();
-        });
-
-        test("t=1", () => {
-            const params = getInputParams(1);
-            const pJac = jacobianSWUP256(curve, params.baseField, params.A, params.B, params.t);
-            expect(pJac.z.equals(new params.baseField(0))).toBeTruthy();
-        });
-
-        test("t=-1", () => {
-            const params = getInputParams(-1);
-            const pJac = jacobianSWUP256(curve, params.baseField, params.A, params.B, params.t);
-            expect(pJac.z.equals(new params.baseField(0))).toBeTruthy();
-        });
     });
 });
 
@@ -243,24 +262,3 @@ describe("point encoding/decoding", () => {
         expect(P.y.equals(newP.y)).toBeTruthy();
     });
 });
-
-/**
- * Creates P256 curve parameters and a value in FF_p
- * @param {int} t optional value in FF_p
- * @return {p;A;B;t} P256 params and an element in FF_p
- */
-function getInputParams(t) {
-    const params = getCurveParams(curve);
-    let eleFFp;
-    if (!t && t != 0) {
-        const byteLength = 32;
-        const wordLength = byteLength / 4; // SJCL 4 bytes to a word
-        const random = sjcl.random.randomWords(wordLength, 10);
-        const rndBits = sjcl.codec.bytes.toBits(random);
-        eleFFp = h2Base(rndBits, curve, "p256_hashing");
-    } else {
-        eleFFp = new params.baseField(t);
-    }
-
-    return {baseField: params.baseField, A: params.A, B: params.B, t: eleFFp};
-}


### PR DESCRIPTION
The implementation of the simplified SWU algorithm was not completely consistent with current IETF draft at https://github.com/chris-wood/draft-irtf-cfrg-hash-to-curve/blob/master/draft-irtf-cfrg-hash-to-curve.txt.

* Updated `h2base` to add `"h2b"` and `len(data)` to the concatenated inputs
* Use test vectors from draft
* Precompute P256 constants
* Remove Jacobian implementation as it was unused

