### PR TITLE
No longer minify source code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       - run: sudo apt install default-jre build-essential
       - checkout
       - run: git submodule update --init
-      - run: yarn install
-      - run: yarn lint
-      - run: yarn build:all
-      - run: yarn test:all
+      - run: make install
+      - run: make lint
+      - run: make build
+      - run: make test

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -115,6 +115,7 @@
         ],
         "indent": ["error", 4, {"SwitchCase": 1}],
         "max-len": 0,
-        "no-redeclare": 0
+        "no-redeclare": 0,
+        "prefer-const": 0
     }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ coverage/
 dist/
 *.zip
 compiled/
+*build.js

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,41 @@
+.PHONY: install
+install:
+	yarn \
+	&& yarn install
+
+.PHONY: lint
+lint:
+	yarn lint
+
+.PHONY: build-sjcl
+build-sjcl:
+	cd src/crypto/sjcl && ./configure --without-all --with-ecc --with-convenience --with-codecBytes --with-codecHex --compress=none && make sjcl.js
+
+.PHONY: build.js
+build.js: src/ext/utils.js src/crypto/sjcl/sjcl.js src/ext/config.js src/ext/h2c.js src/crypto/local.js src/ext/tokens.js src/ext/issuance.js src/ext/redemption.js src/ext/browserUtils.js src/ext/background.js src/ext/listeners.js src/crypto/keccak/keccak.js
+	cat $^ > addon/$@
+
+.PHONY: build
+build: build-sjcl build.js
+
+.PHONY: build-quick
+build: build.js
+
+.PHONY: dist
+dist: build
+	mkdir -p ./dist && cp -a addon/* ./dist/ && rm -rf ./dist/scripts && bestzip ext.zip ./dist && rm -rf ./dist
+
+.PHONY: test-sjcl
+test-sjcl:
+	make test -C src/crypto/sjcl
+
+.PHONY: test-build.js
+test-build.js: src/ext/utils.js src/crypto/sjcl/sjcl.js src/ext/config.js src/ext/h2c.js src/crypto/local.js src/ext/tokens.js src/ext/issuance.js src/ext/redemption.js src/ext/browserUtils.js src/ext/background.js src/crypto/keccak/keccak.js
+	cat $^ > addon/$@
+
+.PHONY: test-ext
+test-ext: test-build.js
+	yarn test:ext-quick
+
+.PHONY: test
+test: test-sjcl test-ext

--- a/README.md
+++ b/README.md
@@ -90,23 +90,20 @@ Documentation for the protocol, workflow and extension components.
     - `test`: Test scripts for using the jest integration test framework.
     - `docs`: Documentation.
 - Commands:
-    - `yarn install`: Installs all dependencies.
-    - `build:all`: Builds all source files (including sjcl) and compiles them
-      (using closure) into minified versions that are kept in `addon/scripts`.
-    - `test:all`: Compiles all source files, excluding `browserUtils.js`, and
-      compiles them (using closure) into test_compiled.js. Runs sjcl tests and
-      the jest test framework for the extension.
-    - `build:ext`: Builds all extension source files and compiles them (using
-      closure) into bg_compiled.js.
-    - `test:ext`: Builds all extension source files, excluding sjcl.
-      `browserUtils.js`, and compiles them (using closure) into bg_compiled.js.
-      Runs the jest test framework for the extension.
-    - `test:ext-quick`: Runs the jest test framework for the extension.
-    - `build:sjcl`: Builds sjcl.
-    - `test:sjcl`: Runs the sjcl tests.
-    - `test:watch`: Runs test:all using the jest --watch flag.
-    - `lint`: Lints the source files.
-    - `dist`: Zips the extension files.
+    - `make install`: Installs all dependencies.
+    - `make build`: Builds all source files (including sjcl) and compiles them
+      into unminified source file at `addon/compiled/build.js`.
+    - `make test`: Builds all source files (except `src/ext/listeners.js`) into
+      a single file and then runs the jest testing framework on this file along
+      with the sjcl tests.
+    - `make build-ext`: Same as `make build` except that it does not build a new
+      version of sjcl.
+    - `make test-ext`: Same as `make test` except that it does not run the sjcl
+      tests.
+    - `make build:sjcl`: Builds sjcl.
+    - `make test:sjcl`: Runs the sjcl tests.
+    - `make lint`: Lints the source files.
+    - `make dist`: Zips the extension files.
 
 ### Firefox
 
@@ -133,8 +130,8 @@ instead.
 ## Plugin overview
 
 The following script files are used for the workflow of Privacy Pass and are
-found in `addon/scripts`. They are compiled into a single file
-(`compiled/bg_compiled.js`) that is then loaded into the browser.
+found in `addon/compiled`. They are compiled into a single file (`build.js`)
+that is then loaded into the browser.
 
 - src/ext/
 	- listeners.js: Initialises the listener functions that are used for the webRequest and webNavigation frameworks.
@@ -153,10 +150,10 @@ found in `addon/scripts`. They are compiled into a single file
   - keccak.js: Local implementation of the Keccak hash function (taken from
     <https://github.com/cryptocoinjs/keccak>).
 
-Files that are used for testing are found in `test/`. These test files use their
-own compiled test file in `compiled/test_compiled.js`. The only difference is
-that src/etx/browserUtils.js is removed for better comptability. Functions from
-this file are mocked during test execution.
+Files that are used for testing are found in `test/`. Some functions from the
+extension files are mocked during test execution. The tests are run on a
+separate file in `addon/compiled/test-build.js` that has the same contents as
+`build.js` but with the HTTP listeners removed.
 
 ## Team
 

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -10,7 +10,7 @@
 
   "background": {
     "scripts": [
-        "compiled/bg_compiled.js"
+        "build.js"
     ]
   },
 

--- a/jest/globals.js
+++ b/jest/globals.js
@@ -39,7 +39,7 @@ window.timeSinceLastResp = 0;
 
 window.workflowSet = () => {
 
-    let workflow = rewire("../addon/compiled/test_compiled.js");
+    let workflow = rewire("../addon/test-build.js");
 
     workflow.__set__("get", getMock);
     workflow.__set__("set", setMock);
@@ -88,7 +88,7 @@ window.workflowSet = () => {
     workflow.__set__("setSpentHosts", setSpentHostsMock);
     workflow.__set__("getSpentHosts", getSpentHostsMock);
 
-    workflow.__set__("createShake256", createShake256);
+    workflow.__set__("shake256", () => {return createShake256();});
     workflow.__set__("clearCachedCommitments", clearCachedCommitmentsMock);
     workflow.__set__("timeSinceLastResp", timeSinceLastResp);
 

--- a/src/crypto/local.js
+++ b/src/crypto/local.js
@@ -19,6 +19,10 @@
 /* exported getActiveECSettings */
 "use strict";
 
+let shake256 = () => {
+    return createShake256();
+};
+
 const BATCH_PROOF_PREFIX = "batch-proof=";
 const MASK = ["0xff", "0x1", "0x3", "0x7", "0xf", "0x1f", "0x3f", "0x7f"];
 
@@ -358,7 +362,7 @@ function recomputeComposites(tokens, signatures, pointG, pointH, prngName) {
     const prng = {name: prngName};
     switch (prng.name) {
         case "shake":
-            prng.func = createShake256();
+            prng.func = shake256();
             prng.func.update(seed, "hex");
             break;
         case "hkdf":

--- a/src/ext/background.js
+++ b/src/ext/background.js
@@ -37,48 +37,48 @@
 const LISTENER_URLS = "<all_urls>";
 // CF config is initialized by default
 let CONFIG_ID = 1;
-const getConfigId = () => CONFIG_ID;
-const setConfigId = (val) => CONFIG_ID = val;
+let getConfigId = () => CONFIG_ID;
+let setConfigId = (val) => CONFIG_ID = val;
 
-const checkConfigId = (configId) => PPConfigs().map((config) => config.id).includes(configId);
+let checkConfigId = (configId) => PPConfigs().map((config) => config.id).includes(configId);
 
-const STORAGE_STR = "bypass-tokens-";
-const COUNT_STR = STORAGE_STR + "count-";
-const activeConfig = () => PPConfigs()[getConfigId()];
-const dev = () => activeConfig()["dev"];
-const chlClearanceCookie = () => activeConfig()["cookies"]["clearance-cookie"];
-const chlCaptchaDomain = () => activeConfig()["captcha-domain"]; // cookies have dots prepended
-const chlVerificationError = () => activeConfig()["error-codes"]["connection-error"];
-const chlConnectionError = () => activeConfig()["error-codes"]["verify-error"];
-const commitmentsKey = () => activeConfig()["commitments"];
-const spendMax = () => activeConfig()["max-spends"];
-const maxTokens = () => activeConfig()["max-tokens"];
-const doSign = () => activeConfig()["sign"];
-const doRedeem = () => activeConfig()["redeem"];
-const redeemMethod = () => activeConfig()["spend-action"]["redeem-method"];
-const headerName = () => activeConfig()["spend-action"]["header-name"];
-const headerHostName = () => activeConfig()["spend-action"]["header-host-name"];
-const headerPathName = () => activeConfig()["spend-action"]["header-path-name"];
-const spendActionUrls = () => activeConfig()["spend-action"]["urls"];
-const spendStatusCode = () => activeConfig()["spending-restrictions"]["status-code"];
-const maxRedirect = () => activeConfig()["spending-restrictions"]["max-redirects"];
-const newTabs = () => activeConfig()["spending-restrictions"]["new-tabs"];
-const badNav = () => activeConfig()["spending-restrictions"]["bad-navigation"];
-const badTransition = () => activeConfig()["spending-restrictions"]["bad-transition"];
-const validRedirects = () => activeConfig()["spending-restrictions"]["valid-redirects"];
-const validTransitions = () => activeConfig()["spending-restrictions"]["valid-transitions"];
-const varReset = () => activeConfig()["var-reset"];
-const varResetMs = () => activeConfig()["var-reset-ms"];
-const storageKeyTokens = () => STORAGE_STR + activeConfig()["id"];
-const storageKeyCount = () => COUNT_STR + activeConfig()["id"];
-const h2cParams = () => activeConfig()["h2c-params"];
-const sendH2CParams = () => activeConfig()["send-h2c-params"];
-const issueActionUrls = () => activeConfig()["issue-action"]["urls"];
-const reloadOnSign = () => activeConfig()["issue-action"]["sign-reload"];
-const signResponseFMT = () => activeConfig()["issue-action"]["sign-resp-format"];
-const tokensPerRequest = () => activeConfig()["issue-action"]["tokens-per-request"];
-const optEndpoints = () => activeConfig()["opt-endpoints"];
-const emptyRespHeaders = () => activeConfig()["spend-action"]["empty-resp-headers"];
+let STORAGE_STR = "bypass-tokens-";
+let COUNT_STR = STORAGE_STR + "count-";
+let activeConfig = () => PPConfigs()[getConfigId()];
+let dev = () => activeConfig()["dev"];
+let chlClearanceCookie = () => activeConfig()["cookies"]["clearance-cookie"];
+let chlCaptchaDomain = () => activeConfig()["captcha-domain"]; // cookies have dots prepended
+let chlVerificationError = () => activeConfig()["error-codes"]["connection-error"];
+let chlConnectionError = () => activeConfig()["error-codes"]["verify-error"];
+let commitmentsKey = () => activeConfig()["commitments"];
+let spendMax = () => activeConfig()["max-spends"];
+let maxTokens = () => activeConfig()["max-tokens"];
+let doSign = () => activeConfig()["sign"];
+let doRedeem = () => activeConfig()["redeem"];
+let redeemMethod = () => activeConfig()["spend-action"]["redeem-method"];
+let headerName = () => activeConfig()["spend-action"]["header-name"];
+let headerHostName = () => activeConfig()["spend-action"]["header-host-name"];
+let headerPathName = () => activeConfig()["spend-action"]["header-path-name"];
+let spendActionUrls = () => activeConfig()["spend-action"]["urls"];
+let spendStatusCode = () => activeConfig()["spending-restrictions"]["status-code"];
+let maxRedirect = () => activeConfig()["spending-restrictions"]["max-redirects"];
+let newTabs = () => activeConfig()["spending-restrictions"]["new-tabs"];
+let badNav = () => activeConfig()["spending-restrictions"]["bad-navigation"];
+let badTransition = () => activeConfig()["spending-restrictions"]["bad-transition"];
+let validRedirects = () => activeConfig()["spending-restrictions"]["valid-redirects"];
+let validTransitions = () => activeConfig()["spending-restrictions"]["valid-transitions"];
+let varReset = () => activeConfig()["var-reset"];
+let varResetMs = () => activeConfig()["var-reset-ms"];
+let storageKeyTokens = () => STORAGE_STR + activeConfig()["id"];
+let storageKeyCount = () => COUNT_STR + activeConfig()["id"];
+let h2cParams = () => activeConfig()["h2c-params"];
+let sendH2CParams = () => activeConfig()["send-h2c-params"];
+let issueActionUrls = () => activeConfig()["issue-action"]["urls"];
+let reloadOnSign = () => activeConfig()["issue-action"]["sign-reload"];
+let signResponseFMT = () => activeConfig()["issue-action"]["sign-resp-format"];
+let tokensPerRequest = () => activeConfig()["issue-action"]["tokens-per-request"];
+let optEndpoints = () => activeConfig()["opt-endpoints"];
+let emptyRespHeaders = () => activeConfig()["spend-action"]["empty-resp-headers"];
 
 /* Config variables that are reset in setConfig() depending on the header value that is received (see config.js) */
 initECSettings(h2cParams());
@@ -100,7 +100,7 @@ let spentHosts = new Map();
 let spentUrl = new Map();
 
 // We want to monitor attempted spends to check if we should remove cookies
-const httpsRedirect = new Map();
+let httpsRedirect = new Map();
 
 // Monitor whether we have already sent tokens for signing
 let sentTokens = new Map();
@@ -118,34 +118,34 @@ let spentTab = new Map();
 let readySign = false;
 
 
-const getSpentUrl = (key) => spentUrl[key];
-const setSpentUrl = (key, value) => spentUrl[key] = value;
+let getSpentUrl = (key) => spentUrl[key];
+let setSpentUrl = (key, value) => spentUrl[key] = value;
 
-const getSpendId = (key) => spendId[key];
-const setSpendId = (key, value) => spendId[key] = value;
+let getSpendId = (key) => spendId[key];
+let setSpendId = (key, value) => spendId[key] = value;
 
-const pushSpentTab = (key, value) => {
+let pushSpentTab = (key, value) => {
     if (!Array.isArray(spentTab[key])) {
         spentTab[key] = [];
     }
     spentTab[key].push(value);
 };
 
-const getSpentHosts = (key) => spentHosts[key];
-const setSpentHosts = (key, value) => spentHosts[key] = value;
+let getSpentHosts = (key) => spentHosts[key];
+let setSpentHosts = (key, value) => spentHosts[key] = value;
 
-const getFutureReload = (key) => futureReload[key];
-const setFutureReload = (key, value) => futureReload[key] = value;
+let getFutureReload = (key) => futureReload[key];
+let setFutureReload = (key, value) => futureReload[key] = value;
 
-const getTarget = (key) => target[key];
-const setTarget = (key, value) => target[key] = value;
+let getTarget = (key) => target[key];
+let setTarget = (key, value) => target[key] = value;
 
-const getHttpsRedirect = (key) => httpsRedirect[key];
-const setHttpsRedirect = (key, value) => httpsRedirect[key] = value;
+let getHttpsRedirect = (key) => httpsRedirect[key];
+let setHttpsRedirect = (key, value) => httpsRedirect[key] = value;
 
-const getRedirectCount = (key) => redirectCount[key];
-const setRedirectCount = (key, value) => redirectCount[key] = value;
-const incrRedirectCount = (key) => redirectCount[key] += 1;
+let getRedirectCount = (key) => redirectCount[key];
+let setRedirectCount = (key, value) => redirectCount[key] = value;
+let incrRedirectCount = (key) => redirectCount[key] += 1;
 
 
 /**

--- a/src/ext/config.js
+++ b/src/ext/config.js
@@ -61,6 +61,8 @@ function exampleConfig() {
         "error-codes": {
             "verify-error": "5", // error code sent by server for verification error
             "connection-error": "6", // error code sent by server for connection error
+            "bad-request-error": "7", // error code sent by server for signalling that a bad request was made
+            "unknown-error": "8", // error code sent by server in case of an unknown error occurring
         }, // generic error codes (can add more)
         "h2c-params": {// parameters for establishing which hash-to-curve setting the client wants to use
             "curve": "p256", // elliptic curve that generated tokens should be mapped to

--- a/src/ext/h2c.js
+++ b/src/ext/h2c.js
@@ -9,7 +9,7 @@
 /* global sjcl */
 /* exported h2Curve */
 
-const H2C_SEED = sjcl.codec.hex.toBits("312e322e3834302e31303034352e332e312e3720706f696e742067656e65726174696f6e2073656564");
+let H2C_SEED = sjcl.codec.hex.toBits("312e322e3834302e31303034352e332e312e3720706f696e742067656e65726174696f6e2073656564");
 const p256Curve = sjcl.ecc.curves.c256;
 const precomputedP256 = {
     // a=-3, but must be reduced mod p for P256; otherwise,

--- a/test/crypto.test.js
+++ b/test/crypto.test.js
@@ -4,8 +4,7 @@
  * @author Alex Davidson
  */
 
-import rewire from "rewire";
-const workflow = rewire("../addon/compiled/test_compiled.js");
+const workflow = workflowSet();
 const sjcl = workflow.__get__("sjcl");
 const evaluateHkdf = workflow.__get__("evaluateHkdf");
 

--- a/test/issuance.test.js
+++ b/test/issuance.test.js
@@ -129,7 +129,7 @@ describe("commitments parsing and caching", () => {
 each(PPConfigs().filter((config) => config.id > 0).map((config) => [config.id]))
     .describe("config_id = %i signing request is cancelled", (configId) => {
         test("signing off", () => {
-            workflow.__with__({DO_SIGN: () => false})(() => {
+            workflow.__with__({doSign: () => false})(() => {
                 const b = beforeRequest(details, url);
                 expect(b).toBeFalsy();
             });


### PR DESCRIPTION
Minified source code is allowed by both Chrome and Firefox but we've had some probelms in the past with store guidelines so it is probably just best to present the source code as is.

Changes:
- Switch to make for building & testing
- Had to change a load of variables from `const` to `let` to allow mocking them during tests