### PR TITLE
Handle more error codes

### DIFF
--- a/src/ext/config.js
+++ b/src/ext/config.js
@@ -61,6 +61,8 @@ function exampleConfig() {
         "error-codes": {
             "verify-error": "5", // error code sent by server for verification error
             "connection-error": "6", // error code sent by server for connection error
+            "bad-request-error": "7", // error code sent by server for signalling that a bad request was made
+            "unknown-error": "8", // error code sent by server in case of an unknown error occurring
         }, // generic error codes (can add more)
         "h2c-params": {// parameters for establishing which hash-to-curve setting the client wants to use
             "curve": "p256", // elliptic curve that generated tokens should be mapped to


### PR DESCRIPTION
We plan to use new error codes in future server implementations that will highlight specific cases where clients have sent bad requests, or whether an unknown error has occurred. These error codes primarily provide information the client during a failed redemption request.

(PR on top of unminified source change to simplify merging later)
