### PR TITLE
Enable linter's configuration in cascade

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,9 +1,7 @@
 src/crypto/asn1/*
 src/crypto/sjcl/*
 src/crypto/keccak/*
-test/*
 jest/*
 addon/*
-test/*
 coverage/*
 jest.config.js

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test": "make test-ext && jest",
     "test-all": "make test-all",
     "dist": "make dist",
-    "lint": "eslint . && cd test && eslint --config .eslintrc.tests.json ."
+    "lint": "eslint ."
   },
   "devDependencies": {
     "jest-each": "^24.5.0"

--- a/src/ext/browserUtils.js
+++ b/src/ext/browserUtils.js
@@ -288,4 +288,4 @@ function clear() {
  * We use this function for updating the popup when tokens are cleared
  * The function is passed from bc-plugin.js
  */
-let UpdateCallback = function() {};
+let UpdateCallback = function() { };

--- a/src/ext/listeners.js
+++ b/src/ext/listeners.js
@@ -78,8 +78,8 @@ chrome.cookies.onChanged.addListener(function(changeInfo) {
             reloadTabForCookie(cookieDomain);
         }
     } else if (changeInfo.removed
-            && cookieName === chlClearanceCookie()
-            && cookieDomain !== "." + chlCaptchaDomain()) {
+        && cookieName === chlClearanceCookie()
+        && cookieDomain !== "." + chlCaptchaDomain()) {
         resetSpendVars();
     }
 });

--- a/src/ext/tokens.js
+++ b/src/ext/tokens.js
@@ -36,7 +36,7 @@ function CreateBlindToken() {
  */
 function GenerateNewTokens(n) {
     let tokens = [];
-    for (let i=0; i<n; i++) {
+    for (let i = 0; i < n; i++) {
         const tok = CreateBlindToken();
         if (!tok) {
             console.warn("[privacy-pass]: Tried to generate a random point on the curve, but failed.");
@@ -67,7 +67,7 @@ function storeNewTokens(tokens, signedPoints) {
     // Append old tokens to the newly received tokens
     if (countStoredTokens() > 0) {
         const oldTokens = loadTokens();
-        for (let i=0; i<oldTokens.length; i++) {
+        for (let i = 0; i < oldTokens.length; i++) {
             const oldT = oldTokens[i];
             storableTokens.push(getTokenEncoding(oldT, oldT.point));
         }

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,5 +1,4 @@
 {
-    "extends": "../.eslintrc.json",
     "parserOptions": {
         "sourceType": "module"
     },

--- a/test/crypto.test.js
+++ b/test/crypto.test.js
@@ -47,7 +47,7 @@ describe("HKDF", () => {
     describe("edge cases", () => {
         test("numBlocks too high", () => {
             expect(() => {
-                evaluateHkdf(testVectors[0].ikm, 257*42, testVectors[0].info, testVectors[0].salt, testVectors[0].hash);
+                evaluateHkdf(testVectors[0].ikm, 257 * 42, testVectors[0].info, testVectors[0].salt, testVectors[0].hash);
             }).toThrowError("HKDF error");
         });
     });

--- a/test/headersReceived.test.js
+++ b/test/headersReceived.test.js
@@ -1,5 +1,4 @@
 /**
-
  * Integrations tests for when headers are received by the extension
  *
  * @author: Alex Davidson


### PR DESCRIPTION
The configuration file inside `test` folder now inherits the configuration setting from the parent folder `/`.
All these changes are cosmetic.