### PR TITLE
HC patch to preserve backwards compatibility

### DIFF
--- a/src/ext/background.js
+++ b/src/ext/background.js
@@ -446,7 +446,7 @@ function beforeRequest(details, url) {
             xhrInfo = signReqCF(url);
             break;
         case 2:
-            xhrInfo = signReqHC(url);
+            xhrInfo = signReqHC(url, details);
             break;
         default:
             throw new Error("Incorrect config ID specified");
@@ -460,6 +460,9 @@ function beforeRequest(details, url) {
 
     // actually send the token signing request via xhr and return the xhr object
     const xhr = sendXhrSignReq(xhrInfo, url, details.tabId);
+    if (xhrInfo.cancel) {
+        return false;
+    }
     return {xhr: xhr};
 }
 

--- a/src/ext/browserUtils.js
+++ b/src/ext/browserUtils.js
@@ -79,8 +79,8 @@ function fireRedeem(url, respTabId) {
     if (!isValidRedeemMethod(redeemMethod())) {
         throw new Error("[privacy-pass]: Incompatible redeem method selected.");
     }
+    setSpendFlag(url.host, true);
     if (redeemMethod() === "reload") {
-        setSpendFlag(url.host, true);
         const targetUrl = getTarget(respTabId);
         if (url.href === targetUrl) {
             chrome.tabs.update(respTabId, {url: targetUrl});

--- a/src/ext/config.js
+++ b/src/ext/config.js
@@ -130,9 +130,9 @@ function PPConfigs() {
     hcConfig["spending-restrictions"]["status-code"] = [200];
     hcConfig["spend-action"]["redeem-method"] = "no-reload";
     hcConfig["spend-action"]["urls"] = ["https://*.hcaptcha.com/getcaptcha", "https://*.hmt.ai/getcaptcha", "http://localhost/getcaptcha"];
-    hcConfig["issue-action"]["urls"] = ["https://*.hcaptcha.com/checkcaptcha/*", "https://*.hmt.ai/checkcaptcha/*", "http://localhost/checkcaptcha/*"];
+    hcConfig["issue-action"]["urls"] = ["https://*.hcaptcha.com/checkcaptcha/*", "https://*.hmt.ai/checkcaptcha/*", "http://127.0.0.1/checkcaptcha/*"];
     hcConfig["issue-action"]["sign-reload"] = false;
-    hcConfig["issue-action"]["sign-response-format"] = "json";
+    hcConfig["issue-action"]["sign-resp-format"] = "json";
     hcConfig.cookies["clearance-cookie"] = "hc_clearance";
     hcConfig["captcha-domain"] = "hcaptcha.com";
     hcConfig["send-h2c-params"] = true;

--- a/src/ext/config.js
+++ b/src/ext/config.js
@@ -122,11 +122,6 @@ function PPConfigs() {
     hcConfig["max-spends"] = undefined;
     hcConfig["max-tokens"] = 300;
     hcConfig["var-reset-ms"] = 2000;
-    hcConfig["pkey-commitments"] =
-        "-----BEGIN PUBLIC KEY-----\n" +
-        "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE4OifvSTxGcy3T/yac6LVugArFb89\n" +
-        "wvqGivp0/54wgeyWkvUZiUdlbIQF7BuGeO9C4sx4nHkpAgRfvd8jdBGz9g==\n" +
-        "-----END PUBLIC KEY-----";
     hcConfig["spending-restrictions"]["status-code"] = [200];
     hcConfig["spend-action"]["redeem-method"] = "no-reload";
     hcConfig["spend-action"]["urls"] = ["https://*.hcaptcha.com/getcaptcha", "https://*.hmt.ai/getcaptcha", "http://127.0.0.1/getcaptcha"];

--- a/src/ext/issuance.js
+++ b/src/ext/issuance.js
@@ -62,15 +62,16 @@ function signReqCF(url) {
 /**
  * hCaptcha issuance request
  * @param {URL} url
+ * @param {DETAILS} details
  * @return {XMLHttpRequest} XHR info for asynchronous token issuance
  */
-function signReqHC(url) {
+function signReqHC(url, details) {
     const reqUrl = url.href;
     const isIssuerUrl = issueActionUrls()
         .map((issuerUrl) => patternToRegExp(issuerUrl))
         .some((re) => reqUrl.match(re));
 
-    if (!isIssuerUrl) {
+    if (!isIssuerUrl || details.method === "OPTIONS") {
         return null;
     }
 
@@ -79,7 +80,7 @@ function signReqHC(url) {
     const tokens = GenerateNewTokens(tokensPerRequest());
     const request = BuildIssueRequest(tokens);
     // Construct info for xhr signing request
-    const xhrInfo = {newUrl: reqUrl, requestBody: `blinded-tokens=${request}&captcha-bypass=true`, tokens: tokens};
+    const xhrInfo = {newUrl: reqUrl, requestBody: `blinded-tokens=${request}&captcha-bypass=true`, tokens: tokens, cancel: true};
     return xhrInfo;
 }
 

--- a/src/ext/issuance.js
+++ b/src/ext/issuance.js
@@ -337,7 +337,6 @@ function retrieveCommitments(xhr, version) {
         verifyCommitments(cmt, getCommitmentsKey());
         // throw new Error("[privacy-pass]: Signature field is missing.");
     }
-   
     return {G: cmt.G, H: cmt.H};
 }
 

--- a/src/ext/issuance.js
+++ b/src/ext/issuance.js
@@ -333,10 +333,11 @@ function retrieveCommitments(xhr, version) {
     if (Date.now() >= expDate) {
         throw new Error("[privacy-pass]: Commitments expired in " + expDate);
     }
-    if (cmt.sig === undefined) {
-        throw new Error("[privacy-pass]: Signature field is missing.");
+    if (cmt.sig !== undefined) {
+        verifyCommitments(cmt, getCommitmentsKey());
+        // throw new Error("[privacy-pass]: Signature field is missing.");
     }
-    verifyCommitments(cmt, getCommitmentsKey());
+   
     return {G: cmt.G, H: cmt.H};
 }
 


### PR DESCRIPTION
This patch preserve hcaptca.com compatibility with the `UpcomingVersionTwo`. In addition to that it fixes some problems in token issuance.

Compatibility is preserved by not verifying commitments if the `sig` key is not present in the pulled commitment. Even tough we have generated keys with the new format, the reference implementation of the bypass server does still not support it. So this change should be inline with other compatibility preserving changes made recently.

@alxdavids we'll be ready to switch to the new format as soon as the new bypass-server becomes available, as usual all feedback regarding this PR is welcome. There might be more changes incoming once we verify the redeem path as well.