### PR TITLE
Use commitments from config, fixes to issue and redeem for no-reload

### DIFF
--- a/src/ext/background.js
+++ b/src/ext/background.js
@@ -460,7 +460,7 @@ function beforeRequest(details, url) {
 
     // actually send the token signing request via xhr and return the xhr object
     const xhr = sendXhrSignReq(xhrInfo, url, details.tabId);
-    
+
     /** In the no-reload paradigm the issuance request is sent along side the original solve request. Requests are reconciled on the backend.
      *  If the captcha solution is correct a signature is returned to the extension, with a 200 status code, if the solution is not correct a 403 status code is returned
      *  to the extension along with any error messages. As both the solve request and the issue request are sent to the same endpoint we must send a `{cancel: false}`

--- a/src/ext/background.js
+++ b/src/ext/background.js
@@ -460,7 +460,13 @@ function beforeRequest(details, url) {
 
     // actually send the token signing request via xhr and return the xhr object
     const xhr = sendXhrSignReq(xhrInfo, url, details.tabId);
-    if (xhrInfo.cancel) {
+    
+    /** In the no-reload paradigm the issuance request is sent along side the original solve request. Requests are reconciled on the backend.
+     *  If the captcha solution is correct a signature is returned to the extension, with a 200 status code, if the solution is not correct a 403 status code is returned
+     *  to the extension along with any error messages. As both the solve request and the issue request are sent to the same endpoint we must send a `{cancel: false}`
+     *  to avoid canceling the original captcha solve request.
+    */
+    if (xhrInfo.cancel === false) {
         return false;
     }
     return {xhr: xhr};

--- a/src/ext/background.js
+++ b/src/ext/background.js
@@ -446,7 +446,7 @@ function beforeRequest(details, url) {
             xhrInfo = signReqCF(url);
             break;
         case 2:
-            xhrInfo = signReqHC(url);
+            xhrInfo = signReqHC(url, details);
             break;
         default:
             throw new Error("Incorrect config ID specified");
@@ -460,6 +460,9 @@ function beforeRequest(details, url) {
 
     // actually send the token signing request via xhr and return the xhr object
     const xhr = sendXhrSignReq(xhrInfo, url, details.tabId);
+    if (xhrInfo.cancel) {
+        return false;
+    }
     return {xhr: xhr};
 }
 

--- a/src/ext/browserUtils.js
+++ b/src/ext/browserUtils.js
@@ -79,8 +79,8 @@ function fireRedeem(url, respTabId) {
     if (!isValidRedeemMethod(redeemMethod())) {
         throw new Error("[privacy-pass]: Incompatible redeem method selected.");
     }
+    setSpendFlag(url.host, true);
     if (redeemMethod() === "reload") {
-        setSpendFlag(url.host, true);
         const targetUrl = getTarget(respTabId);
         if (url.href === targetUrl) {
             chrome.tabs.update(respTabId, {url: targetUrl});

--- a/src/ext/config.js
+++ b/src/ext/config.js
@@ -129,13 +129,19 @@ function PPConfigs() {
         "-----END PUBLIC KEY-----";
     hcConfig["spending-restrictions"]["status-code"] = [200];
     hcConfig["spend-action"]["redeem-method"] = "no-reload";
-    hcConfig["spend-action"]["urls"] = ["https://*.hcaptcha.com/getcaptcha", "https://*.hmt.ai/getcaptcha", "http://localhost/getcaptcha"];
-    hcConfig["issue-action"]["urls"] = ["https://*.hcaptcha.com/checkcaptcha/*", "https://*.hmt.ai/checkcaptcha/*", "http://localhost/checkcaptcha/*"];
+    hcConfig["spend-action"]["urls"] = ["https://*.hcaptcha.com/getcaptcha", "https://*.hmt.ai/getcaptcha", "http://127.0.0.1/getcaptcha"];
+    hcConfig["issue-action"]["urls"] = ["https://*.hcaptcha.com/checkcaptcha/*", "https://*.hmt.ai/checkcaptcha/*", "http://127.0.0.1/checkcaptcha/*"];
     hcConfig["issue-action"]["sign-reload"] = false;
-    hcConfig["issue-action"]["sign-response-format"] = "json";
+    hcConfig["issue-action"]["sign-resp-format"] = "json";
     hcConfig.cookies["clearance-cookie"] = "hc_clearance";
     hcConfig["captcha-domain"] = "hcaptcha.com";
     hcConfig["send-h2c-params"] = true;
+    hcConfig["commitments"] = {
+        "1.0": {
+            "G": "BMKCnVDWUEBNiyAR+p0YT7QvtrOfpHAeatzipwo6x98Ch1q3ZoCkNdiQvUTEwDzG20RplG/IE2NCpsXZGLsUdvA=",
+            "H": "BNJIpofS4RhbUfnkblr5yvuymaEfV+ViKshsoN9DkCRaHBB+TiKUnicc14gBswpLfBaKXuC102Cvwzq3YIN8dVo=",
+        },
+    };
 
     // Ordering of configs should correspond to value of cf-chl-bypass header
     // i.e. the first config should have "id": 1, the second "id":2, etc.

--- a/src/ext/issuance.js
+++ b/src/ext/issuance.js
@@ -62,7 +62,7 @@ function signReqCF(url) {
 /**
  * hCaptcha issuance request
  * @param {URL} url
- * @param {DETAILS} details
+ * @param {Object} details
  * @return {XMLHttpRequest} XHR info for asynchronous token issuance
  */
 function signReqHC(url, details) {
@@ -79,8 +79,8 @@ function signReqHC(url, details) {
     // Generate tokens and create a JSON request for signing
     const tokens = GenerateNewTokens(tokensPerRequest());
     const request = BuildIssueRequest(tokens);
-    // Construct info for xhr signing request
-    const xhrInfo = {newUrl: reqUrl, requestBody: `blinded-tokens=${request}&captcha-bypass=true`, tokens: tokens, cancel: true};
+    // Construct info for xhr signing request, set `cancel: false` in order to prevent canceling the original captcha solve request.
+    const xhrInfo = {newUrl: reqUrl, requestBody: `blinded-tokens=${request}&captcha-bypass=true`, tokens: tokens, cancel: false};
     return xhrInfo;
 }
 

--- a/src/ext/issuance.js
+++ b/src/ext/issuance.js
@@ -62,15 +62,16 @@ function signReqCF(url) {
 /**
  * hCaptcha issuance request
  * @param {URL} url
+ * @param {DETAILS} details
  * @return {XMLHttpRequest} XHR info for asynchronous token issuance
  */
-function signReqHC(url) {
+function signReqHC(url, details) {
     const reqUrl = url.href;
     const isIssuerUrl = issueActionUrls()
         .map((issuerUrl) => patternToRegExp(issuerUrl))
         .some((re) => reqUrl.match(re));
 
-    if (!isIssuerUrl) {
+    if (!isIssuerUrl || details.method === "OPTIONS") {
         return null;
     }
 
@@ -79,7 +80,7 @@ function signReqHC(url) {
     const tokens = GenerateNewTokens(tokensPerRequest());
     const request = BuildIssueRequest(tokens);
     // Construct info for xhr signing request
-    const xhrInfo = {newUrl: reqUrl, requestBody: `blinded-tokens=${request}&captcha-bypass=true`, tokens: tokens};
+    const xhrInfo = {newUrl: reqUrl, requestBody: `blinded-tokens=${request}&captcha-bypass=true`, tokens: tokens, cancel: true};
     return xhrInfo;
 }
 
@@ -237,7 +238,7 @@ function validateAndStoreTokens(url, tabId, tokens, issueResp) {
     const version = checkVersion(issueResp.version);
     let commitments;
     // retrieve CF 1.0 commitments from source code or cache otherwise
-    if (version === "1.0" && getConfigName() === "CF") {
+    if (version === "1.0") {
         commitments = storedCommitments()[version];
     } else {
         commitments = getCachedCommitments(version);


### PR DESCRIPTION
@alxdavids Resubmitting our latest compatibility fixes, as per your suggestion we're using commitments from `config.js`, also fixing some issues we've found with the `no-reload` method.

Feedback is very welcome!