### PR TITLE
Remove captcha-domain

### DIFF
--- a/src/ext/config.js
+++ b/src/ext/config.js
@@ -134,7 +134,7 @@ function PPConfigs() {
     hcConfig["issue-action"]["sign-reload"] = false;
     hcConfig["issue-action"]["sign-resp-format"] = "json";
     hcConfig.cookies["clearance-cookie"] = "hc_clearance";
-    hcConfig["captcha-domain"] = "hcaptcha.com";
+    hcConfig["captcha-domain"] = null;
     hcConfig["send-h2c-params"] = true;
     hcConfig["commitments"] = {
         "1.0": {


### PR DESCRIPTION
@alxdavids while we were testing latest version on our production stack we realized that the `captcha-domain` config setting is completely breaking our redeem flow. Our production URLs are actually on the captcha domain itself, which of course make redeem impossible. Unfortunately we did not put two and two together until now.

It would we incredibly helpful if you could merge this and push out a new version of the extension ASAP.

Thank you!