### PR TITLE
`Get more passes` url based on activeConfig

### DIFF
--- a/addon/popup/bc-plugin.html
+++ b/addon/popup/bc-plugin.html
@@ -18,8 +18,8 @@
   </div>
 
   <div>
-    <a href="https://captcha.website" target="_blank">
-      <button type='button' class="button-style" formaction="captcha.website">Get More Passes</button>
+    <a href="https://captcha.website" target="_blank" id='website'>
+      <button type='button' class="button-style">Get More Passes</button>
     </a>
   </div>
 

--- a/addon/popup/bc-plugin.js
+++ b/addon/popup/bc-plugin.js
@@ -18,7 +18,7 @@ function UpdatePopup() {
     let tokLen = 0
     if (background) {
         tokLen = background.countStoredTokens();
-        handleResponse(tokLen);
+        handleResponse(tokLen, background.getMorePassesUrl());
     } else {
         let send = browser.runtime.sendMessage({
             tokLen: true
@@ -27,9 +27,10 @@ function UpdatePopup() {
     }
 }
 
-function handleResponse(tokLen) {
+function handleResponse(tokLen, url) {
     // Replace the count displayed in the popup
     replaceTokensStoredCount(tokLen);
+    document.getElementById("website").setAttribute("href", url)
 
     document.getElementById("clear").addEventListener("click", function() {
         if (background) {

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -214,7 +214,7 @@ of tokens before they browse.
 
 A valid URL string specifying an url where users can get more signed tokens by solving a 
 challange/CAPTCHA. This URL is pulled into the pop-up `Get more passes` menu item. 
-Can be different from `captcha-domain`, and must be a valid URL.
+Can be different from `captcha-domain`, and must be a valid URL with protocol specified.
 
 ### config\["opt-endpoints"\]
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -210,6 +210,12 @@ A string specifying a domain where users can obtain signed tokens by solving a
 challenge/CAPTCHA. This is helpful to allow users to build up initial stockpiles
 of tokens before they browse.
 
+### config\["get-more-passes-url"\]
+
+A valid URL string specifying an url where users can get more signed tokens by solving a 
+challange/CAPTCHA. This URL is pulled into the pop-up `Get more passes` menu item. 
+Can be different from `captcha-domain`, and must be a valid URL.
+
 ### config\["opt-endpoints"\]
 
 Optional endpoints for use by the particular configuration.

--- a/jest/globals.js
+++ b/jest/globals.js
@@ -74,7 +74,6 @@ window.workflowSet = () => {
     workflow.__set__("setTarget", setTargetMock);
     workflow.__set__("getTarget", getTargetMock);
 
-
     workflow.__set__("spendId", spendIdMock);
     workflow.__set__("setSpendId", setSpendIdMock);
     workflow.__set__("getSpendId", getSpendIdMock);

--- a/src/ext/background.js
+++ b/src/ext/background.js
@@ -93,7 +93,6 @@ let optEndpoints = () => activeConfig()["opt-endpoints"];
 let emptyRespHeaders = () => activeConfig()["spend-action"]["empty-resp-headers"];
 let storedCommitments = () => activeConfig()["commitments"];
 
-
 /**
  * Allows access to get-more-passes-url from UpdatePopup
  * @return {string}

--- a/src/ext/background.js
+++ b/src/ext/background.js
@@ -34,6 +34,7 @@
 /* exported getConfigName */
 /* exported storedCommitments */
 /* exported requestIdentifiers */
+/* exported getMorePassesUrl */
 
 "use strict";
 
@@ -91,6 +92,15 @@ let tokensPerRequest = () => activeConfig()["issue-action"]["tokens-per-request"
 let optEndpoints = () => activeConfig()["opt-endpoints"];
 let emptyRespHeaders = () => activeConfig()["spend-action"]["empty-resp-headers"];
 let storedCommitments = () => activeConfig()["commitments"];
+
+
+/**
+ * Allows access to get-more-passes-url from UpdatePopup
+ * @return {string}
+ */
+function getMorePassesUrl() {
+    return activeConfig()["get-more-passes-url"];
+}
 
 /* Config variables that are reset in setConfig() depending on the header value that is received (see config.js) */
 initECSettings(h2cParams());

--- a/src/ext/config.js
+++ b/src/ext/config.js
@@ -72,6 +72,7 @@ function exampleConfig() {
             "clearance-cookie": "", // name of clearance cookies for checking (cookies that are optionally acquired after redemption occurs)
         },
         "captcha-domain": "", // optional domain for acquiring tokens
+        "get-more-passes-url": "", // optional url that the Get More Passes menu item will point
         "opt-endpoints": {}, // optional endpoints for integration-specific operations
         "error-codes": {
             "connection-error": "5", // error code sent by server for connection error
@@ -115,6 +116,7 @@ function PPConfigs() {
     cfConfig["issue-action"]["request-identifiers"]["post-processed"] = "captcha-bypass";
     cfConfig.cookies["clearance-cookie"] = "cf_clearance";
     cfConfig["captcha-domain"] = "captcha.website";
+    cfConfig["get-more-passes-url"] = "https://captcha.website";
     cfConfig["send-h2c-params"] = true;
     cfConfig["opt-endpoints"].challenge = "/cdn-cgi/challenge";
     cfConfig["spend-action"]["empty-resp-headers"] = ["direct-request"];
@@ -143,6 +145,7 @@ function PPConfigs() {
     hcConfig["issue-action"]["sign-resp-format"] = "json";
     hcConfig.cookies["clearance-cookie"] = "hc_clearance";
     hcConfig["captcha-domain"] = null;
+    hcConfig["get-more-passes-url"] = "https://hcaptcha.com";
     hcConfig["send-h2c-params"] = true;
     hcConfig["commitments"] = {
         "1.0": {

--- a/src/ext/config.js
+++ b/src/ext/config.js
@@ -72,7 +72,7 @@ function exampleConfig() {
             "clearance-cookie": "", // name of clearance cookies for checking (cookies that are optionally acquired after redemption occurs)
         },
         "captcha-domain": "", // optional domain for acquiring tokens
-        "get-more-passes-url": "", // optional url that the Get More Passes menu item will point
+        "get-more-passes-url": "", // optional url that the Get More Passes menu item will point, must be valid URL with protocol
         "opt-endpoints": {}, // optional endpoints for integration-specific operations
         "error-codes": {
             "connection-error": "5", // error code sent by server for connection error

--- a/src/ext/config.js
+++ b/src/ext/config.js
@@ -96,6 +96,7 @@ function exampleConfig() {
  */
 function PPConfigs() {
     // The configuration used by Cloudflare
+    const cfDomain = "captcha.website";
     const cfConfig = exampleConfig();
     cfConfig.id = 1;
     cfConfig.dev = false;
@@ -115,8 +116,8 @@ function PPConfigs() {
     cfConfig["issue-action"]["request-identifiers"]["body-param"] = "g-recaptcha-response";
     cfConfig["issue-action"]["request-identifiers"]["post-processed"] = "captcha-bypass";
     cfConfig.cookies["clearance-cookie"] = "cf_clearance";
-    cfConfig["captcha-domain"] = "captcha.website";
-    cfConfig["get-more-passes-url"] = "https://captcha.website";
+    cfConfig["captcha-domain"] = cfDomain;
+    cfConfig["get-more-passes-url"] = `https://${cfDomain}`;
     cfConfig["send-h2c-params"] = true;
     cfConfig["opt-endpoints"].challenge = "/cdn-cgi/challenge";
     cfConfig["spend-action"]["empty-resp-headers"] = ["direct-request"];

--- a/src/ext/config.js
+++ b/src/ext/config.js
@@ -145,7 +145,7 @@ function PPConfigs() {
     hcConfig["issue-action"]["sign-resp-format"] = "json";
     hcConfig.cookies["clearance-cookie"] = "hc_clearance";
     hcConfig["captcha-domain"] = null;
-    hcConfig["get-more-passes-url"] = "https://hcaptcha.com";
+    hcConfig["get-more-passes-url"] = "https://www.hcaptcha.com/privacy-pass";
     hcConfig["send-h2c-params"] = true;
     hcConfig["commitments"] = {
         "1.0": {

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -13,6 +13,7 @@
         "getFutureReloadMock": true,
         "getHttpsRedirectMock": true,
         "getMock": true,
+        "getMorePAssesUrl": true,
         "getRedirectCountMock": true,
         "getSpendFlagMock": true,
         "getSpendIdMock": true,
@@ -63,8 +64,7 @@
         "validateRespMock": true,
         "workersG": true,
         "workersH": true,
-        "workflowSet": true,
-        "getMorePAssesUrl": true
+        "workflowSet": true
     },
     "rules": {
         "no-func-assign": 0,

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -63,7 +63,8 @@
         "validateRespMock": true,
         "workersG": true,
         "workersH": true,
-        "workflowSet": true
+        "workflowSet": true,
+        "getMorePAssesUrl": true
     },
     "rules": {
         "no-func-assign": 0,

--- a/test/browserNavigation.test.js
+++ b/test/browserNavigation.test.js
@@ -2,7 +2,7 @@
  * Integrations tests for processing redirections
  *
  * @author: Alex Davidson
- * @author Drazen Urch
+ * @author: Drazen Urch
  */
 
 const workflow = workflowSet();

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -20,6 +20,6 @@ each(PPConfigs().filter((config) => config.id > 0).map((config) => [config.id]))
         });
 
         test("ensure `get-more-passes-url` is a valid URL", () => {
-            new URL(activeConfig()['get-more-passes-url']);
-        })
-    })
+            new URL(activeConfig()["get-more-passes-url"]);
+        });
+    });

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,0 +1,25 @@
+/**
+ * Test config.js parameters for all providers
+ *
+ * @author: Drazen Urch
+ */
+
+import each from "jest-each";
+
+const workflow = workflowSet();
+
+const PPConfigs = workflow.__get__("PPConfigs");
+const getConfigId = workflow.__get__("getConfigId");
+
+let activeConfig = () => PPConfigs()[getConfigId()];
+
+each(PPConfigs().filter((config) => config.id > 0).map((config) => [config.id]))
+    .describe("CONFIG_ID = %i", (configId) => {
+        beforeEach(() => {
+            workflow.__set__("CONFIG_ID", configId);
+        });
+
+        test("ensure `get-more-passes-url` is a valid URL", () => {
+            new URL(activeConfig()['get-more-passes-url']);
+        })
+    })

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -22,4 +22,18 @@ each(PPConfigs().filter((config) => config.id > 0).map((config) => [config.id]))
         test("ensure `get-more-passes-url` is a valid URL", () => {
             new URL(activeConfig()["get-more-passes-url"]);
         });
+
+        test("ensure config `get-more-passes-url` value is correct", () => {
+            const url = activeConfig()["get-more-passes-url"];
+            let correctValue;
+            switch (configId) {
+                case 1:
+                    correctValue = "https://captcha.website";
+                    break;
+                case 2:
+                    correctValue = "https://www.hcaptcha.com/privacy-pass";
+                    break;
+            }
+            expect(url === correctValue).toBeTruthy();
+        });
     });

--- a/test/crypto.test.js
+++ b/test/crypto.test.js
@@ -1,7 +1,7 @@
 /**
  * Tests for cryptographic functionality
  *
- * @author Alex Davidson
+ * @author; Alex Davidson
  */
 
 const workflow = workflowSet();


### PR DESCRIPTION
Sets `Get more passes` url based on the currently active config. Still a WIP while we settle on the URL to use for HC config. 

Additionally I've noticed an issue with CF issuance, namely I can't seem to get any tokens from `captcha.website`. While this is unrelated to the changes above we have been getting complaints along the lines of what I'm seeing. So I'll spend some time looking into that as well.