### PR TITLE
Update manifest version to v2.0.6

### DIFF
--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -2,7 +2,7 @@
   "description": "Handles passes containing cryptographically blinded tokens for bypassing internet challenge.",
   "manifest_version": 2,
   "name": "Privacy Pass",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "icons": {
     "48": "icons/ticket-48.png"
   },

--- a/src/ext/config.js
+++ b/src/ext/config.js
@@ -18,7 +18,7 @@
  * @return {string} Extension version
  */
 function extVersion() {
-    return browser.runtime.getManifest().version;
+    return chrome.runtime.getManifest().version;
 }
 
 /**


### PR DESCRIPTION
Also includes a change to replace:
```
browser.runtime.getManifestVersion().version
```
with:
```
chrome.runtime.getManifestVersion().version
```
since Chrome does not support `browser`. This does not impact Firefox.