### PR TITLE
Update required permissions and description

### DIFF
--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -1,8 +1,8 @@
 {
-  "description": "Handles passes containing cryptographically blinded tokens for bypassing internet challenge.",
+  "description": "Client support for Privacy Pass anonymous authorization protocol.",
   "manifest_version": 2,
   "name": "Privacy Pass",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "icons": {
     "48": "icons/ticket-48.png"
   },
@@ -12,10 +12,8 @@
     ]
   },
   "permissions": [
-    "alarms",
     "cookies",
     "<all_urls>",
-    "storage",
     "tabs",
     "webRequest",
     "webRequestBlocking",


### PR DESCRIPTION
Should hopefully fix #197. I think the Chrome store requires us to remove some permissions that were not being used. I've removed the "storage" and "alarms" permissions as there were no longer any references. I also updated the description to be a little more accurate.

cc @armfazh, @claucece. It would be good if you could do some more testing to ensure that everything works.