### PR TITLE
Removing tabs permission as not required.

### DIFF
--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -17,7 +17,6 @@
   "permissions": [
     "cookies",
     "<all_urls>",
-    "tabs",
     "webRequest",
     "webRequestBlocking",
     "webNavigation"


### PR DESCRIPTION
This change is required for v2.0.7