### PR TITLE
Use callbacks instead of events

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -77,7 +77,7 @@ chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
         // Update the browser action icon after clearing the tokens.
         const activeTab = window.TABS.get(window.ACTIVE_TAB_ID);
         if (activeTab !== undefined) {
-            activeTab.updateIcon();
+            activeTab.forceUpdateIcon();
         }
         return;
     }

--- a/src/background/providers/hcaptcha.ts
+++ b/src/background/providers/hcaptcha.ts
@@ -1,14 +1,27 @@
-import { Provider } from '.';
+import { Callbacks, Provider } from '.';
 
 export class HcaptchaProvider implements Provider {
     static readonly ID: number = 2;
+    private callbacks: Callbacks;
+
+    constructor(callbacks: Callbacks) {
+        this.callbacks = callbacks;
+    }
 
     getID(): number {
         return HcaptchaProvider.ID;
     }
 
-    getBadgeText(): string {
+    private getBadgeText(): string {
         return 'N/A';
+    }
+
+    forceUpdateIcon(): void {
+        this.callbacks.updateIcon(this.getBadgeText());
+    }
+
+    handleActivated(): void {
+        this.callbacks.updateIcon(this.getBadgeText());
     }
 
     handleBeforeRequest(

--- a/src/background/providers/index.ts
+++ b/src/background/providers/index.ts
@@ -3,7 +3,7 @@ export { HcaptchaProvider } from './hcaptcha';
 
 export interface Provider {
     getID(): number;
-    getBadgeText(): string;
+    forceUpdateIcon(): void;
     handleBeforeRequest(
         details: chrome.webRequest.WebRequestBodyDetails,
     ): chrome.webRequest.BlockingResponse | void;
@@ -13,4 +13,10 @@ export interface Provider {
     handleBeforeSendHeaders(
         details: chrome.webRequest.WebRequestHeadersDetails,
     ): chrome.webRequest.BlockingResponse | void;
+    handleActivated(): void;
+}
+
+export interface Callbacks {
+    updateIcon(text: string): void;
+    navigateUrl(url: string): void;
 }


### PR DESCRIPTION
For icon updating, we allow the provider to explicitly actively update
the icon using the callback instead of using the event listeners
implemented in the Tab class. By doing this, the provider has the
freedom to update the icon any time it wants.

For tab reloading, we move the logic to the Tab class so that the
provider doesn't have to use the Chrome API directly and allow the
provider to reload the tab using the callback in the same way as in icon
updating.