### PR TITLE
Change cloudflare issue request flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "privacy-pass",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "contributors": [
         "Suphanat Chunhapanya <pop@cloudflare.com>",
         "Armando Faz <armfazh@cloudflare.com>"

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,7 +2,7 @@
     "name": "Privacy Pass",
     "manifest_version": 2,
     "description": "Client support for Privacy Pass anonymous authorization protocol.",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "icons": {
         "32": "icons/32/gold.png",
         "48": "icons/48/gold.png",

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -21,8 +21,27 @@ declare global {
     }
 }
 
+declare let browser: any;
+
 window.ACTIVE_TAB_ID = chrome.tabs.TAB_ID_NONE;
 window.TABS = new Map<number, Tab>();
+
+const BROWSERS = {
+    CHROME: 'Chrome',
+    FIREFOX: 'Firefox',
+    EDGE: 'Edge',
+} as const;
+type BROWSERS = typeof BROWSERS[keyof typeof BROWSERS];
+
+function getBrowser(): BROWSERS {
+    if (typeof chrome !== 'undefined') {
+        if (typeof browser !== 'undefined') {
+            return BROWSERS.FIREFOX;
+        }
+        return BROWSERS.CHROME;
+    }
+    return BROWSERS.EDGE;
+}
 
 /* Listeners for navigator */
 
@@ -57,10 +76,14 @@ chrome.webRequest.onBeforeRequest.addListener(handleBeforeRequest, { urls: ['<al
     'blocking',
 ]);
 
+const extraInfos = ['requestHeaders', 'blocking'];
+if (getBrowser() === BROWSERS.CHROME) {
+    extraInfos.push('extraHeaders');
+}
 chrome.webRequest.onBeforeSendHeaders.addListener(
     handleBeforeSendHeaders,
     { urls: ['<all_urls>'] },
-    ['requestHeaders', 'blocking'],
+    extraInfos,
 );
 
 chrome.webRequest.onHeadersReceived.addListener(handleHeadersReceived, { urls: ['<all_urls>'] }, [

--- a/src/background/providers/cloudflare.ts
+++ b/src/background/providers/cloudflare.ts
@@ -13,8 +13,7 @@ const ISSUANCE_BODY_PARAM_NAME = 'blinded-tokens';
 const COMMITMENT_URL =
     'https://raw.githubusercontent.com/privacypass/ec-commitments/master/commitments-p256.json';
 
-const QUALIFIED_QUERY_PARAMS = ['__cf_chl_captcha_tk__', '__cf_chl_managed_tk__'];
-const QUALIFIED_BODY_PARAMS = ['g-recaptcha-response', 'h-captcha-response', 'cf_captcha_kind'];
+const QUALIFIED_BODY_PARAMS = ['h-captcha-response', 'cf_captcha_kind'];
 
 const CHL_BYPASS_SUPPORT = 'cf-chl-bypass';
 const DEFAULT_ISSUING_HOSTNAME = 'captcha.website';
@@ -237,13 +236,10 @@ export class CloudflareProvider implements Provider {
             return;
         }
 
-        const hasQueryParams = QUALIFIED_QUERY_PARAMS.some((param) => {
-            return url.searchParams.has(param);
-        });
-        const hasBodyParams = QUALIFIED_BODY_PARAMS.some((param) => {
+        const hasBodyParams = QUALIFIED_BODY_PARAMS.every((param) => {
             return details.requestBody !== null && param in details.requestBody.formData!;
         });
-        if (!hasQueryParams || !hasBodyParams) {
+        if (!hasBodyParams) {
             return;
         }
 


### PR DESCRIPTION
Since we don't have any query param in the issue request any more, we remove the code which uses the query params to identify the issue request.

Currently we have a Referer header. We also need to use that header in the issue request as well. However such change requires a change in the code structure, as follows:

Previously we used axios to send an issuance request in handleBeforeRequest, but now we will send the request in
handleBeforeSendHeaders because we need to read the Referer header first.

After reading the Referer header, we extract the __cf_chl_tk query param in the Referer url and add the __cf_chl_f_tk query param with that token in the issuance request URL.

We need a new "issueInfo" property to remember the request body we can read in handleBeforeRequest and then it will be read in handleBeforeSendHeaders so that in handleBeforeSendHeaders we will have both the body and the Referer header.
