### PR TITLE
Update the body param

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "privacy-pass",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "contributors": [
         "Suphanat Chunhapanya <pop@cloudflare.com>",
         "Armando Faz <armfazh@cloudflare.com>"

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,7 +2,7 @@
     "name": "Privacy Pass",
     "manifest_version": 2,
     "description": "Client support for Privacy Pass anonymous authorization protocol.",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "icons": {
         "32": "icons/32/gold.png",
         "48": "icons/48/gold.png",

--- a/src/background/providers/cloudflare.test.ts
+++ b/src/background/providers/cloudflare.test.ts
@@ -107,7 +107,7 @@ describe('issuance', () => {
                 requestBody: {
                     formData: {
                         ['h-captcha-response']: ['body-param'],
-                        ['cf_captcha_kind']: ['body-param'],
+                        ['cf_ch_verify']: ['body-param'],
                     },
                 },
             };
@@ -120,13 +120,13 @@ describe('issuance', () => {
             expect(issueInfo!.requestId).toEqual(details.requestId);
             expect(issueInfo!.formData).toStrictEqual({
                 ['h-captcha-response']: 'body-param',
-                ['cf_captcha_kind']: 'body-param',
+                ['cf_ch_verify']: 'body-param',
             });
         });
 
         /*
          * The request is invalid only if the body has both
-         * 'h-captcha-response' and 'cf_captcha_kind' params.
+         * 'h-captcha-response' and 'cf_ch_verify' params.
          */
         test('invalid request', async () => {
             const storage = new StorageMock();
@@ -174,7 +174,7 @@ describe('issuance', () => {
                 requestId: 'xxx',
                 formData: {
                     ['h-captcha-response']: 'body-param',
-                    ['cf_captcha_kind']: 'body-param',
+                    ['cf_ch_verify']: 'body-param',
                 },
             };
             provider['issueInfo'] = issueInfo;
@@ -202,7 +202,7 @@ describe('issuance', () => {
             expect(issue.mock.calls.length).toBe(1);
             expect(issue).toHaveBeenCalledWith('https://captcha.website/?__cf_chl_f_tk=token', {
                 ['h-captcha-response']: 'body-param',
-                ['cf_captcha_kind']: 'body-param',
+                ['cf_ch_verify']: 'body-param',
             });
 
             expect(navigateUrl.mock.calls.length).toBe(1);
@@ -230,7 +230,7 @@ describe('issuance', () => {
                 requestId: 'xxx',
                 formData: {
                     ['h-captcha-response']: 'body-param',
-                    ['cf_captcha_kind']: 'body-param',
+                    ['cf_ch_verify']: 'body-param',
                 },
             };
             provider['issueInfo'] = issueInfo;
@@ -253,7 +253,7 @@ describe('issuance', () => {
             expect(issue.mock.calls.length).toBe(1);
             expect(issue).toHaveBeenCalledWith('https://captcha.website/?__cf_chl_f_tk=token', {
                 ['h-captcha-response']: 'body-param',
-                ['cf_captcha_kind']: 'body-param',
+                ['cf_ch_verify']: 'body-param',
             });
 
             expect(navigateUrl.mock.calls.length).toBe(1);

--- a/src/background/providers/cloudflare.ts
+++ b/src/background/providers/cloudflare.ts
@@ -13,7 +13,7 @@ const ISSUANCE_BODY_PARAM_NAME = 'blinded-tokens';
 const COMMITMENT_URL =
     'https://raw.githubusercontent.com/privacypass/ec-commitments/master/commitments-p256.json';
 
-const QUALIFIED_BODY_PARAMS = ['h-captcha-response', 'cf_captcha_kind'];
+const QUALIFIED_BODY_PARAMS = ['h-captcha-response', 'cf_ch_verify'];
 
 const CHL_BYPASS_SUPPORT = 'cf-chl-bypass';
 const DEFAULT_ISSUING_HOSTNAME = 'captcha.website';


### PR DESCRIPTION
I think we cannot use h-captcha-response alone because otherwise there
will be no indicator that indicates it's a Cloudflare website.

And cf_captcha_kind is no longer available, let's use cf_ch_verify
instead.

Solving #306 